### PR TITLE
[easy] another n_exs fix for MT validation

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -611,7 +611,7 @@ class MultiTaskModel(nn.Module):
 
         if isinstance(task, MTTask):
             decoder = getattr(self, "%s_decoder" % task.name)
-            out = decoder.forward(sent, sent_mask, batch['targs'])
+            out.update(decoder.forward(sent, sent_mask, batch['targs']))
             task.scorer1(math.exp(out['loss'].item()))
             return out
 


### PR DESCRIPTION
Test plan:

python main.py  --config_file config/defaults.conf --overrides "exp_name = wmt_en_de_katherin_baseline, run_name = wmt_en_
de_default, train_tasks = wmt14_en_de, eval_tasks = glue, patience= 100, lr_decay_factor = 0.95, min_lr = 0.000001"

07/10 03:47:54 AM: Update 939: task wmt14_en_de, batch 939 (939): perplexity: 1438.7564, wmt14_en_de_loss: 7.0249 ||
07/10 03:48:04 AM: Update 950: task wmt14_en_de, batch 950 (950): perplexity: 1430.4110, wmt14_en_de_loss: 7.0196 ||
07/10 03:48:15 AM: Update 972: task wmt14_en_de, batch 972 (972): perplexity: 1414.2132, wmt14_en_de_loss: 7.0089 ||
07/10 03:48:25 AM: Update 994: task wmt14_en_de, batch 994 (994): perplexity: 1399.1031, wmt14_en_de_loss: 6.9996 ||
07/10 03:48:28 AM: ***** Pass 1000 / Epoch 1 *****
07/10 03:48:28 AM: wmt14_en_de: trained on 1000 batches, 0.009 epochs
07/10 03:48:28 AM: Validating...
07/10 03:48:35 AM: Batch 37/157: perplexity: 542.0302, wmt14_en_de_loss: 6.2833 ||
07/10 03:48:45 AM: Batch 87/157: perplexity: 541.7193, wmt14_en_de_loss: 6.2857 ||
