### PR TITLE
ELMo saving fix

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -741,7 +741,7 @@ class SamplingMultiTaskTrainer():
 
         model_state = self._model.state_dict()
 
-        keys_to_save = []
+        # Skip non-trainable params, like the main ELMo params.
         for name, param in self._model.named_parameters():
             if not param.requires_grad:
                 del model_state[name]


### PR DESCRIPTION
#147 

Verified in demo.conf—previously, restored parameters didn't match saved parameters. Now appears correct.