### PR TITLE
Delete 'prepreproc'

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -276,8 +276,6 @@ def build_tasks(args):
     '''
 
     # 1) create / load tasks
-    prepreproc_dir = os.path.join(args.exp_dir, "prepreproc")
-    utils.maybe_make_dir(prepreproc_dir)
     tasks, train_task_names, eval_task_names = \
         get_tasks(parse_task_list_arg(args.train_tasks), parse_task_list_arg(args.eval_tasks), args.max_seq_len,
                   path=args.data_dir, scratch_path=args.exp_dir,


### PR DESCRIPTION
This is currently an unused variable, but we also make a directory. I don't see anywhere else in the code this is used, so this should be safe.