### PR TITLE
Bug fix for MTL

### DIFF
--- a/config/demo.conf
+++ b/config/demo.conf
@@ -15,7 +15,7 @@ include "defaults.conf"  // relative path to this file
 // write to local storage by default for this demo
 project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = "jiant-demo"
-run_name = "sst"
+run_name = "mtl-sst-mrpc"
 global_ro_exp_dir = "/nfs/jsalt/share/exp/demo"
 
 cuda = 0
@@ -28,7 +28,7 @@ reload_tasks = 0
 reload_indexing = 0
 reload_vocab = 0
 
-train_tasks = "sst"
+train_tasks = "sst,mrpc"
 eval_tasks = "sts-b"
 do_train = 1
 do_eval = 1

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -482,8 +482,7 @@ class SamplingMultiTaskTrainer():
                 preds_file_path_dict = {task.name: os.path.join(
                     self._serialization_dir,
                     "preds_{}{}_{}_epoch_{}.txt".format(
-                        time.time(), task.name, phase, epoch))
-                }
+                        time.time(), task.name, phase, epoch)) for task in tasks}
                 all_val_metrics, should_save, new_best_macro = self._validate(
                     epoch, tasks, batch_size, periodic_save=(phase != "eval"), preds_file_path_dict=preds_file_path_dict)
 


### PR DESCRIPTION
There was a bug in the trainer that would break on all MTL experiments. This PR fixes that and sets up `demo.conf` to be a MTL demo (sst and mrpc) so that we can easily catch breaking changes to MTL in the future.