### PR TITLE
[s2sfinal] reduce vocab to 20k

### DIFF
--- a/config/final.conf
+++ b/config/final.conf
@@ -12,8 +12,8 @@ patience = 20
 max_vals = 10000
 
 // for all generation tasks
-max_word_v_size = 30000
-max_targ_word_v_size = 30000
+max_word_v_size = 20000
+max_targ_word_v_size = 20000
 
 // for MTL
 weighting_method = power_0.75


### PR DESCRIPTION
We need to go down to 20k vocab on all 16 s2s final experiments (due to cuda OOM).