### PR TITLE
Add failsafe assert around reuse of pretraining params in eval training

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -40,6 +40,9 @@ do_eval = 1     // run eval steps
 load_model = 1  // if true, restore main training from checkpoint if available
 load_eval_checkpoint = "none"  // path to eval checkpoint, or "none"
 allow_untrained_encoder_parameters = 0 // Set for experiments involving random untrained RNNs only.
+allow_reuse_of_pretraining_parameters = 0 // Set to 1 to allow task models that were trained during pretraining from  
+                                          // being reused in train_for_eval. This may behave incorrectly if 
+                                          // training is stopped and restarted (issues #285, #290).
 reload_tasks = 0     // if true, force reloading tasks
 reload_indexing = 0  // if true, force reindexing tasks for tasks in reindex_tasks
 reindex_tasks = ""

--- a/main.py
+++ b/main.py
@@ -172,6 +172,13 @@ def main(cl_arguments):
         steps_log.append("Re-training model for individual eval tasks")
         assert_for_log(args.eval_val_interval % args.bpp_base == 0,
                        "Error: eval_val_interval [%d] must be divisible by bpp_base [%d]" % (args.eval_val_interval,args.bpp_base))
+        assert_for_log(len(set(train_tasks).intersection(eval_tasks)) == 0 \
+                        or args.allow_reuse_of_pretraining_parameters \
+                        or args.do_train == 0,
+                        "If you're pretraining on a task you plan to reuse as a target task, set\n"
+                        "allow_reuse_of_pretraining_parameters = 1(risky), or train in two steps:\n"
+                        "  train with do_train = 1, train_for_eval = 0, stop, and restart with\n"
+                        "  do_train = 0 and train_for_eval = 1.")
 
     if args.do_eval:
         assert_for_log(args.eval_tasks != "none",
@@ -208,7 +215,7 @@ def main(cl_arguments):
     else:
         strict = False
 
-    if args.train_for_eval:
+    if args.train_for_eval and not args.allow_reuse_of_pretraining_parameters:
         # If we're training models for evaluation, which is always done from scratch with a fresh
         # optimizer, we shouldn't load parameters for those models. 
         # Usually, there won't be trained parameters to skip, but this can happen if a run is killed


### PR DESCRIPTION
This should prevent us from doing dumb things wrt. issues #285/#290.