### PR TITLE
Edgeprobe script cleanup

### DIFF
--- a/major_experiment_scripts/edgeprobe_exp_fns.sh
+++ b/major_experiment_scripts/edgeprobe_exp_fns.sh
@@ -5,7 +5,8 @@
 # experiment script as:
 # 
 #   export NOTIFY_EMAIL="yourname@gmail.com"
-#   source edgeprobe_exp_fns.sh
+#   pushd /path/to/jiant
+#   source major_experiment_scripts/edgeprobe_exp_fns.sh
 #   elmo_chars_exp edges-srl-conll2005
 #   elmo_full_exp edges-srl-conll2005
 #   elmo_ortho_exp edges-srl-conll2005 0


### PR DESCRIPTION
Bash functions to run all the current edge probing experiments. Putting these all in one file that we can import, so that we're not locked in to a particular machine configuration by the structure of the existing scripts (`edgeprobe_elmo_baselines.sh` and friends).