### PR TITLE
Remove hard-coded project name

### DIFF
--- a/gcp/create_instance.sh
+++ b/gcp/create_instance.sh
@@ -50,10 +50,9 @@ fi
 
 set -x
 gcloud compute instances create "$INSTANCE_NAME" \
-  --project jsalt-sentence-rep --zone "$ZONE" \
-  --source-instance-template "$TEMPLATE"
+  --zone "$ZONE" --source-instance-template "$TEMPLATE"
 set +x
 
 echo "Instance created! Wait a minute or two before attempting to SSH."
-STATUS_URL="https://console.cloud.google.com/compute/instancesDetail/zones/$ZONE/instances/$INSTANCE_NAME?project=jsalt-sentence-rep"
+STATUS_URL="https://console.cloud.google.com/compute/instancesDetail/zones/$ZONE/instances/$INSTANCE_NAME"
 echo "You can monitor status at: $STATUS_URL"

--- a/gcp/remote_job.sh
+++ b/gcp/remote_job.sh
@@ -23,7 +23,7 @@ fi
 FULL_COMMAND="bash -l -c \"${COMMAND}\""
 
 set -x
-gcloud compute ssh --project jsalt-sentence-rep --zone "$ZONE" \
+gcloud compute ssh --zone "$ZONE" \
   "${INSTANCE_NAME}" --command="${FULL_COMMAND}" -- -t
 
 set +x

--- a/gcp/remote_job_tmux.sh
+++ b/gcp/remote_job_tmux.sh
@@ -42,7 +42,7 @@ else
 fi
 
 set -x
-gcloud compute ssh --project jsalt-sentence-rep --zone "$ZONE" \
+gcloud compute ssh --zone "$ZONE" \
   "${INSTANCE_NAME}" --command="${FULL_COMMAND}" -- -t
 
 


### PR DESCRIPTION
Just use the default project as configured by `gcloud init`.