### PR TITLE
GCP scripts use internal ip if running from GCE

### DIFF
--- a/gcp/remote_job.sh
+++ b/gcp/remote_job.sh
@@ -22,9 +22,22 @@ fi
 
 FULL_COMMAND="bash -l -c \"${COMMAND}\""
 
+declare -a CL_ARGS
+
+# Use internal ip between GCE instances.
+# We use a DNS lookup to tell if the local host is a GCE instance. See
+# https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
+dig_response=$(dig +short metadata.google.internal)
+if [[ "$dig_response" != "" ]]; then
+  CL_ARGS+=( --internal-ip )
+fi
+CL_ARGS+=( "${INSTANCE_NAME}" )
+CL_ARGS+=( --command "${FULL_COMMAND}" )
+CL_ARGS+=( --zone "$ZONE")
+CL_ARGS+=( -- -t )
+
 set -x
-gcloud compute ssh --zone "$ZONE" \
-  "${INSTANCE_NAME}" --command="${FULL_COMMAND}" -- -t
+gcloud beta compute ssh "${CL_ARGS[@]}"
 
 set +x
 echo "Remote command completed successfully."

--- a/gcp/remote_job_tmux.sh
+++ b/gcp/remote_job_tmux.sh
@@ -41,8 +41,21 @@ else
   FULL_COMMAND+="tmux attach -t ${JOB_NAME}"
 fi
 
+declare -a CL_ARGS
+
+# Use internal ip between GCE instances.
+# We use a DNS lookup to tell if the local host is a GCE instance. See
+# https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
+dig_response=$(dig +short metadata.google.internal)
+if [[ "$dig_response" != "" ]]; then
+  CL_ARGS+=( --internal-ip )
+fi
+CL_ARGS+=( "${INSTANCE_NAME}" )
+CL_ARGS+=( --command "${FULL_COMMAND}" )
+CL_ARGS+=( --zone "$ZONE")
+CL_ARGS+=( -- -t )
+
 set -x
-gcloud compute ssh --zone "$ZONE" \
-  "${INSTANCE_NAME}" --command="${FULL_COMMAND}" -- -t
+gcloud beta compute ssh "${CL_ARGS[@]}"
 
 


### PR DESCRIPTION
Allow running jobs on workers if the GCP project has firewall rules preventing remote SSH. This is mostly needed for a separate environment I'm using, but it shouldn't change functionality on the jsalt-sentence-rep project.