### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@
 #       python $JIANT_PATH/main.py --config_file $JIANT_PATH/demo.conf \
 #       [ ... additional args to main.py ... ]
 #
-# To run on Kubernetes, see gcp/kubernetes/jiant_run.sh
-#
 # Note that --remote_log currently doesn't work with the above command,
 # since the host name seen by main.py is the name of the container, not the
 # name of the host GCE instance.


### PR DESCRIPTION
When a problem comes along, you must ship it! Ship it good!

See comment in Dockerfile for example usage.

Container spec with all dependencies, including CUDA and environment vars for running on our GCP setup. Intentionally _does not_ include a copy of this repo, since that might change frequently for experiments and the Docker image is rather large. We might want to change that before release, since including code in the image is much better for repeatability. 

TODO to factor out environment vars, and to switch to miniconda for a smaller image size.