### PR TITLE
Fix some internal padding value issues

### DIFF
--- a/src/modules.py
+++ b/src/modules.py
@@ -140,7 +140,7 @@ class SentenceEncoder(Model):
                 sent_enc = torch.cat([sent_enc, skip_vec], dim=-1)
 
         sent_mask = sent_mask.unsqueeze(dim=-1)
-        pad_mask = (sent_mask == 0) #1 - sent_mask.byte().data
+        pad_mask = (sent_mask == 0)
         sent_enc = sent_enc.masked_fill(pad_mask, 0)
         return sent_enc, sent_mask
 
@@ -192,7 +192,7 @@ class Pooler(nn.Module):
     def forward(self, sequence, mask):
         if len(mask.size()) < 3:
             mask = mask.unsqueeze(dim=-1)
-        pad_mask = (mask == 0) #1 - mask.byte().data
+        pad_mask = (mask == 0)
         proj_seq = self.project(sequence) # linear project each hid state
         if self.pool_type == 'max':
             proj_seq = proj_seq.masked_fill(pad_mask, -float('inf'))


### PR DESCRIPTION
I don't think this affect any results (because _I think_ we're setting things to -inf or 0 when we need to), but this change will make the sentence encoder return a sequence with pad elements all zero (we missed this because of the skip embeddings).

Also uses more ternary operations for assignments.

Ran on demo w/ and w/o skip embeddings (ELMo chars only).