### PR TITLE
Edge probing: replace projection layer with CNN

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -222,6 +222,9 @@ classifier_loss_fn = ""  // Classifier loss function. Used only in some speciali
 classifier_span_pooling = "x,y"  // Span pooling type (for edge probing only).
                                  // Options: 'attn' or one of the 'combination' arguments accepted by AllenNLP's
                                  //   EndpointSpanExtractor.
+edgeprobe_cnn_context = 0  // expanded context for edge probing via CNN.
+                           // 0 looks at only the current word, 1 adds +/-
+                           // words (kernel width 3), etc.
 d_hid_dec = 300  // The hidden size of the decoder in seq2seq tasks.
 n_layers_dec = 1  // The number of decoder layers in seq2seq tasks.
 mt_attention = "bilinear"  // Attention used in s2s. Current implemented options are "bilinear" and "none".

--- a/src/models.py
+++ b/src/models.py
@@ -412,6 +412,7 @@ def get_task_specific_params(args, task_name):
     # Used for edge probing. Other tasks can safely ignore.
     params['cls_loss_fn'] = _get_task_attr("classifier_loss_fn")
     params['cls_span_pooling'] = _get_task_attr("classifier_span_pooling")
+    params['edgeprobe_cnn_context'] = _get_task_attr("edgeprobe_cnn_context")
 
     # For NLI probing tasks, might want to use a classifier trained on
     # something else (typically 'mnli').


### PR DESCRIPTION
Use `edgeprobe_cnn_context=0` to behave as a linear layer, but can set to > 0 to learn a wider kernel. This allows for using local context around the specified span, and allows the probing model to correct for offsets (such as the off-by-one issue for language models) in the representations.