### PR TITLE
bugfix: snli processing

### DIFF
--- a/scripts/download_glue_data.py
+++ b/scripts/download_glue_data.py
@@ -66,6 +66,7 @@ def format_snli(data_dir):
             to_write = current_row[:10] # first 9 are valid information
             to_write.append(current_row[-1]) # last index is the gold label
             train_writer.write("\t".join(to_write))
+            train_writer.write("\n")
     os.remove(os.path.join(snli_dir, "train.tsv"))
     os.rename(os.path.join(snli_dir, "train_cleaned.tsv"), os.path.join(snli_dir, "train.tsv"))
     print("\tCompleted!")


### PR DESCRIPTION
Right now, the snli cleanup writes all of the training examples to a single line. I added one line to take care of the fix. Thanks!