### PR TITLE
Fix order of checkpointing to not create extra checkpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -289,11 +289,6 @@ def main(cl_arguments):
         # Look for eval checkpoints (available only if we're restoring from a run that already
         # finished), then look for training checkpoints.
 
-        if args.transfer_paradigm == "finetune":
-            # Save model so we have a checkpoint to go back to after each task-specific finetune.
-            model_state = model.state_dict()
-            model_path = os.path.join(args.run_dir, "model_state_untrained_pre_target_train.th")
-            torch.save(model_state, model_path)
         best_path = get_best_checkpoint_path(args.run_dir)
         if best_path:
             load_model_state(model, best_path, args.cuda, task_names_to_avoid_loading,
@@ -301,6 +296,13 @@ def main(cl_arguments):
         else:
             assert_for_log(args.allow_untrained_encoder_parameters,
                            "No best checkpoint found to evaluate.")
+
+            if args.transfer_paradigm == "finetune":
+                # Save model so we have a checkpoint to go back to after each task-specific finetune.
+                model_state = model.state_dict()
+                model_path = os.path.join(args.run_dir, "model_state_untrained_pre_target_train.th")
+                torch.save(model_state, model_path)
+
             log.warning("Evaluating untrained encoder parameters!")
 
     # Train just the task-specific components for eval tasks.


### PR DESCRIPTION
Move where we create the untrained checkpoint (for referring back to when fine-tuning on multiple target tasks w/o pretraining).