### PR TITLE
Remove the last vestige of beam search

### DIFF
--- a/src/modules/seq2seq_decoder.py
+++ b/src/modules/seq2seq_decoder.py
@@ -196,26 +196,6 @@ class Seq2SeqDecoder(Model):
 
         return output_dict
 
-    def _decoder_step(self,
-                      decoder_input,
-                      decoder_hidden,
-                      decoder_context):
-        """
-        Applies one step of the decoder. This is used by beam search.
-
-        Parameters
-        ----------
-        decoder_input: torch.FloatTensor
-        decoder_hidden: torch.FloatTensor
-        decoder_context: torch.FloatTensor
-        """
-        decoder_hidden, decoder_context = self._decoder_cell(
-            decoder_input, (decoder_hidden, decoder_context))
-
-        logits = self._output_projection_layer(decoder_hidden)
-
-        return logits, (decoder_hidden, decoder_context)
-
     def _prepare_decode_step_input(
             self,
             input_indices: torch.LongTensor,


### PR DESCRIPTION
Our beam search implementation was never complete and bug free. It's mostly gone, but I'm getting rid of one last bit of unsupported code here.