### PR TITLE
Remove `is_probing_task` flag

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -110,7 +110,6 @@ reload_vocab = 0     // If true, force the rebuilding of the vocabulary files in
                      // directory. For classification and
                      // regression tasks with the default ELMo-style character handling, there 
                      // is no vocabulary.
-is_probing_task = 0  // Set if the tasks in target_tasks are NLI-style probing tasks.
 
 // Learning curves
 target_train_data_fraction = 1  // Use only the specified fraction of the training data in the 

--- a/config/edgeprobe_existing.conf
+++ b/config/edgeprobe_existing.conf
@@ -37,4 +37,3 @@ do_target_task_training = 1
 write_preds = "val"
 
 elmo_chars_only = 1
-is_probing_task = 0

--- a/main.py
+++ b/main.py
@@ -444,9 +444,6 @@ def main(cl_arguments):
             )
         for task in target_tasks:
             # Skip mnli-diagnostic
-            # This has to be handled differently than probing tasks because probing tasks require the "is_probing_task"
-            # to be set to True. For mnli-diagnostic this flag will be False because it is part of GLUE and
-            # "is_probing_task is global flag specific to a run, not to a task.
             if task.name == "mnli-diagnostic":
                 continue
 

--- a/src/models.py
+++ b/src/models.py
@@ -485,22 +485,9 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
         This function gets the task-specific parameters and builds
         the task-specific modules.
     """
-    if args.is_probing_task:
-        # TODO: move this logic to preprocess.py;
-        # current implementation reloads MNLI data, which is slow.
-        train_task_whitelist, eval_task_whitelist = get_task_whitelist(args)
-        tasks_to_build, _, _ = get_tasks(
-            train_task_whitelist,
-            eval_task_whitelist,
-            args.max_seq_len,
-            path=args.data_dir,
-            scratch_path=args.exp_dir,
-        )
-    else:
-        tasks_to_build = tasks
 
     # Attach task-specific params.
-    for task in set(tasks + tasks_to_build):
+    for task in set(tasks):
         task_params = get_task_specific_params(args, task.name)
         log.info("\tTask '%s' params: %s", task.name, json.dumps(task_params.as_dict(), indent=2))
         # Store task-specific params in case we want to access later

--- a/src/models.py
+++ b/src/models.py
@@ -300,24 +300,6 @@ def build_model(args, vocab, pretrained_embs, tasks):
     return model
 
 
-def get_task_whitelist(args):
-    """Filters tasks so that we only build models that we will use, meaning we only
-    build models for train tasks and for classifiers of eval tasks"""
-    eval_task_names = parse_task_list_arg(args.target_tasks)
-    eval_clf_names = []
-    for task_name in eval_task_names:
-        override_clf = config.get_task_attr(args, task_name, "use_classifier")
-        if override_clf == "none" or override_clf is None:
-            eval_clf_names.append(task_name)
-        else:
-            eval_clf_names.append(override_clf)
-    train_task_names = parse_task_list_arg(args.pretrain_tasks)
-    log.info(
-        "Whitelisting train tasks=%s, eval_clf_tasks=%s", str(train_task_names), str(eval_clf_names)
-    )
-    return train_task_names, eval_clf_names
-
-
 def build_embeddings(args, vocab, tasks, pretrained_embs=None):
     """ Build embeddings according to options in args """
     d_emb, d_char = 0, args.d_char


### PR DESCRIPTION
Previously, we used `is_probing_task` and `get_task_whitelist` to load tasks (e.g. MNLI) whose classifier we are using for another task (e.g. some probing task), but we don't want to train on the source task (e.g. because we have a pretrained model). No task actually uses this option now, so let's drop it. This means that if you want to use task A's classifier for task B, you must load task A and task B (and either train on it or do it in two runs).

addresses issue #372 