### PR TITLE
Remove pool type logic

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -308,8 +308,6 @@ onlstm_tying = 0  // Language Modeling tying of weights.
 // for many tasks, but defaults are set here.
 
 // Model
-pool_type = max  // The type of pooling to aggregate sequences of vectors into a single vector.
-                 // Options: first, last, max, mean.
 classifier = mlp  // The type of the final layer(s) in classification and regression tasks.
                   // Options:
                   //   log_reg: Softmax layer with no additional hidden layer.


### PR DESCRIPTION
Deals with #631 by removing dead pool_type option. If important later, we can expose this again. Will use max pooling for everything except BERT, where we use "first" pooling