### PR TITLE
Remove extra logging (jiant-side)

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ from src.utils.utils import (
     maybe_make_dir,
     parse_json_diff,
     sort_param_recursive,
-    select_relevant_print_args
+    select_relevant_print_args,
 )
 import jsondiff
 

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from src.utils.utils import (
     load_model_state,
     maybe_make_dir,
     parse_json_diff,
-    sort_param_recursive
+    sort_param_recursive,
 )
 import jsondiff
 
@@ -332,7 +332,7 @@ def select_relevant_print_args(args):
         pyhocon.ConfigFactory.parse_string(default_config_string, basedir=default_basedir).items()
     )
     sorted_exp_config = sort_param_recursive(exp_config)
-    sorted_defaults_config = sort_paramgit_recursive(default_config)
+    sorted_defaults_config = sort_param_recursive(default_config)
     diff_args = parse_json_diff(jsondiff.diff(sorted_defaults_config, sorted_exp_config))
     diff_args = config.Params.clone(diff)
     result_args = select_task_specific_args(args, diff_args)
@@ -361,7 +361,7 @@ def select_task_specific_args(exp_args, diff_args):
                 # special logic for edges since there are edge versions of various
                 # tasks.
                 param_task = task
-        # Add parameters that pertain to the experiment tasks 
+        # Add parameters that pertain to the experiment tasks
         if param_task and param_task in exp_tasks:
             diff_args[key] = value
     return diff_args

--- a/main.py
+++ b/main.py
@@ -461,10 +461,6 @@ def main(cl_arguments):
 
     # For checkpointing logic
     if not args.do_target_task_training:
-        log.info(
-            "In strict mode because do_target_task_training is off. "
-            "Will crash if any tasks are missing from the checkpoint."
-        )
         strict = True
     else:
         strict = False

--- a/src/models.py
+++ b/src/models.py
@@ -173,10 +173,8 @@ def build_sent_encoder(args, vocab, d_emb, tasks, embedder, cove_layer):
             cove_layer=cove_layer,
         )
         d_sent = 2 * args.d_hid
-        log.info("Using BiLM architecture for shared encoder!")
     elif args.sent_enc == "bow":
         sent_encoder = BoWSentEncoder(vocab, embedder)
-        log.info("Using BoW architecture for shared encoder!")
         assert_for_log(
             not args.skip_embs, "Skip connection not currently supported with `bow` encoder."
         )
@@ -194,7 +192,6 @@ def build_sent_encoder(args, vocab, d_emb, tasks, embedder, cove_layer):
             cove_layer=cove_layer,
         )
         d_sent = 2 * args.d_hid
-        log.info("Using BiLSTM architecture for shared encoder!")
     elif args.sent_enc == "transformer":
         transformer = StackedSelfAttentionEncoder.from_params(copy.deepcopy(tfm_params))
         sent_encoder = SentenceEncoder(

--- a/src/models.py
+++ b/src/models.py
@@ -476,7 +476,11 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
     # Attach task-specific params.
     for task in set(tasks):
         task_params = get_task_specific_params(args, task.name)
-        log.info("\tTask '%s' params: %s", task.name, json.dumps(task_params.as_dict(), indent=2))
+        log.info(
+            "\tTask '%s' params: %s",
+            task.name,
+            json.dumps(task_params.as_dict(quiet=True), indent=2),
+        )
         # Store task-specific params in case we want to access later
         setattr(model, "%s_task_params" % task.name, task_params)
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -141,4 +141,5 @@ def params_from_file(config_files: Union[str, Iterable[str]], overrides: str = N
 def write_params(params, config_file):
     config = pyhocon.ConfigFactory.from_dict(params.as_dict())
     with open(config_file, "w") as fd:
+        import pdb; pdb.set_trace()
         fd.write(hocon_writer.HOCONConverter.to_hocon(config, indent=2))

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -141,5 +141,4 @@ def params_from_file(config_files: Union[str, Iterable[str]], overrides: str = N
 def write_params(params, config_file):
     config = pyhocon.ConfigFactory.from_dict(params.as_dict())
     with open(config_file, "w") as fd:
-        import pdb; pdb.set_trace()
         fd.write(hocon_writer.HOCONConverter.to_hocon(config, indent=2))

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -134,7 +134,7 @@ def load_model_state(model, state_path, gpu_id, skip_task_models=[], strict=True
             del model_state[key]
 
     model.load_state_dict(model_state, strict=False)
-    logging.info("fdel state from %s", state_path)
+    logging.info("Loaded model state from %s", state_path)
 
 
 def get_elmo_mixing_weights(text_field_embedder, task=None):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -9,10 +9,11 @@ import os
 import random
 import time
 from typing import Dict, Iterable, List, Optional, Sequence, Union
-import jsondiff
+
 
 import numpy as np
 import torch
+import jsondiff
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
@@ -20,6 +21,8 @@ from allennlp.nn.util import device_mapping, masked_softmax
 from nltk.tokenize.moses import MosesDetokenizer
 from torch.autograd import Variable
 from torch.nn import Dropout, Linear, Parameter, init
+
+from .config import Params
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -45,7 +48,7 @@ def wrap_singleton_string(item: Union[Sequence, str]):
     return item
 
 
-def sort_configtrees_in_param_recursive(data):
+def sort_param_recursive(data):
     """
     Sorts the keys of a config.Params object in a param object recursively.
     """
@@ -53,7 +56,7 @@ def sort_configtrees_in_param_recursive(data):
 
     if isinstance(data, dict) and not isinstance(data, pyhocon.ConfigTree):
         for name, _ in list(data.items()):
-            data[name] = sort_configtrees_in_param_recursive(data[name])
+            data[name] = sort_param_recursive(data[name])
     else:
         if isinstance(data, pyhocon.ConfigTree):
             data = dict(sorted(data.items(), key=lambda x: x[0]))
@@ -91,6 +94,76 @@ def parse_json_diff(diff):
             if output:
                 diff[name] = output
     return diff
+
+
+def select_relevant_print_args(args):
+    """
+        Selects relevant arguments to print out. 
+        We select relevant arguments as the difference between defaults.conf and the experiment's 
+        configuration. 
+
+        Params
+        -----------
+        args: Params object
+
+        Returns
+        -----------
+        return_args: Params object with only relevant arguments
+        """
+    import pyhocon
+
+    exp_config_file = os.path.join(args.run_dir, "params.conf")
+    defaults_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)).split("jiant")[0] + "jiant/config/defaults.conf"
+    )
+    exp_basedir = os.path.dirname(exp_config_file)
+    default_basedir = os.path.dirname(defaults_file)
+    fd = open(exp_config_file, "r")
+    exp_config_string = fd.read()
+    exp_config_string += "\n"
+    fd = open(defaults_file, "r")
+    default_config_string = fd.read()
+    default_config_string += "\n"
+    exp_config = dict(
+        pyhocon.ConfigFactory.parse_string(exp_config_string, basedir=exp_basedir).items()
+    )
+    default_config = dict(
+        pyhocon.ConfigFactory.parse_string(default_config_string, basedir=default_basedir).items()
+    )
+    sorted_exp_config = sort_param_recursive(exp_config)
+    sorted_defaults_config = sort_param_recursive(default_config)
+    diff_args = parse_json_diff(jsondiff.diff(sorted_defaults_config, sorted_exp_config))
+    diff_args = Params.clone(diff_args)
+    result_args = select_task_specific_args(args, diff_args)
+    return result_args
+
+
+def select_task_specific_args(exp_args, diff_args):
+    """
+    A helper function that adds in task-specific parameters from the experiment 
+    configurations for tasks in pretrain_tasks and target_tasks.
+    """
+    exp_tasks = []
+    if diff_args.get("pretrain_tasks"):
+        exp_tasks = diff_args.pretrain_tasks.split(",")
+    if diff_args.get("target_tasks"):
+        exp_tasks += diff_args.target_tasks.split(",")
+    if len(exp_tasks) == 0:
+        return diff_args
+    for key, value in list(exp_args.as_dict().items()):
+        stripped_key = key.replace("_", " ")
+        stripped_key = stripped_key.replace("-", " ")
+        param_task = None
+        # For each parameter, identify the task the parameter relates to (if any)
+        for task in exp_tasks:
+            if task in stripped_key and (("edges" in stripped_key) == ("edges" in task)):
+                # special logic for edges since there are edge versions of various
+                # tasks.
+                param_task = task
+        # Add parameters that pertain to the experiment tasks
+        if param_task and param_task in exp_tasks:
+            diff_args[key] = value
+    return diff_args
 
 
 def load_model_state(model, state_path, gpu_id, skip_task_models=[], strict=True):

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,69 @@
+import csv
+import os
+import shutil
+import tempfile
+import unittest
+import pyhocon
+import jsondiff
+
+import src.utils.utils as utils
+
+
+class TestParseJsonDiff(unittest.TestCase):
+    def test_replace_insert_parse_json_diff(self):
+        output_diff = {
+            "mrpc": {
+                jsondiff.replace: pyhocon.ConfigTree(
+                    [
+                        ("classifier_dropout", 0.1),
+                        ("classifier_hid_dim", 256),
+                        ("max_vals", 8),
+                        ("val_interval", 1),
+                    ]
+                )
+            }
+        }
+        parsed_diff = utils.parse_json_diff(output_diff)
+        assert isinstance(parsed_diff["mrpc"], pyhocon.ConfigTree)
+        output_diff = {
+            "mrpc": {
+                jsondiff.insert: pyhocon.ConfigTree(
+                    [
+                        ("classifier_dropout", 0.1),
+                        ("classifier_hid_dim", 256),
+                        ("max_vals", 8),
+                        ("val_interval", 1),
+                    ]
+                )
+            }
+        }
+        parsed_diff = utils.parse_json_diff(output_diff)
+        assert isinstance(parsed_diff["mrpc"], pyhocon.ConfigTree)
+
+    def test_delete_parse_json_diff(self):
+        output_diff = {"mrpc": {jsondiff.delete: [1], "lr": 0.001}}
+        parsed_diff = utils.parse_json_diff(output_diff)
+        assert jsondiff.delete not in parsed_diff["mrpc"].keys()
+
+
+class TestSortRecursively(unittest.TestCase):
+    def test_replace_insert_parse_json_diff(self):
+        input_diff = {
+            "mrpc": pyhocon.ConfigTree(
+                [
+                    ("classifier_hid_dim", 256),
+                    ("max_vals", 8),
+                    ("classifier_dropout", 0.1),
+                    ("val_interval", 1),
+                ]
+            ),
+            "rte": {"configs": pyhocon.ConfigTree([("b", 1), ("a", 3)])},
+        }
+        sorted_diff = utils.sort_configtrees_in_param_recursive(input_diff)
+        assert list(sorted_diff["mrpc"].items()) == [
+            ("classifier_dropout", 0.1),
+            ("classifier_hid_dim", 256),
+            ("max_vals", 8),
+            ("val_interval", 1),
+        ]
+        assert list(sorted_diff["rte"]["configs"].items()) == [("a", 3), ("b", 1)]

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -59,7 +59,7 @@ class TestSortRecursively(unittest.TestCase):
             ),
             "rte": {"configs": pyhocon.ConfigTree([("b", 1), ("a", 3)])},
         }
-        sorted_diff = utils.sort_configtrees_in_param_recursive(input_diff)
+        sorted_diff = utils.sort_param_recursive(input_diff)
         assert list(sorted_diff["mrpc"].items()) == [
             ("classifier_dropout", 0.1),
             ("classifier_hid_dim", 256),


### PR DESCRIPTION
This removes extra logging from #602 , more specifically:
-A lot of the 1-line logs (easy case). 
-The unrelated parameter arguments that were being printed out. Here, we use union of (a diff between the experiment configurations and defaults.conf) and task-specific parameters for tasks used in the experiments 

Now, after this change, the log for the parameters for demo.conf are as below:
{
  "batch_size": 8,
  "classifier_hid_dim": 32,
  "d_word": 50,
  "exp_dir": "coreference_exp/jiant-demo/",
  "exp_name": "jiant-demo",
  "load_model": 0,
  "local_log_path": "coreference_exp/jiant-demo/new_5/log.log",
  "max_seq_len": 10,
  "max_vals": 10,
  "max_word_v_size": 1000,
  "mrpc": {
    "classifier_dropout": 0.1,
    "classifier_hid_dim": 256,
    "max_vals": 8,
    "val_interval": 1
  },
  "mrpc_classifier_dropout": 0.2,
  "mrpc_classifier_hid_dim": 256,
  "mrpc_d_proj": 256,
  "mrpc_lr": 0.0003,
  "mrpc_pair_attn": 0,
  "mrpc_val_interval": 100,
  "pretrain_tasks": "sst,mrpc",
  "random_seed": 42,
  "remote_log_name": "jiant-demo__new_5",
  "run_dir": "coreference_exp/jiant-demo/new_5",
  "run_name": "new_5",
  "sent_enc": "bow",
  "skip_embs": 0,
  "sst": {},
  "sst_classifier_dropout": 0.2,
  "sst_classifier_hid_dim": 256,
  "sst_d_proj": 256,
  "sst_lr": 0.0003,
  "sst_val_interval": 100,
  "sts-b": {
    "classifier_dropout": 0.3,
    "classifier_hid_dim": 512,
    "max_vals": 16,
    "pair_attn": 0,
    "val_interval": 10
  },
  "target_tasks": "sts-b,wnli",
  "target_train_max_vals": 10,
  "target_train_val_interval": 10,
  "val_interval": 50,
  "wnli": {},
  "wnli_classifier_dropout": 0.4,
  "wnli_classifier_hid_dim": 128,
  "wnli_d_proj": 128,
  "wnli_lr": 0.0003,
  "wnli_pair_attn": 0,
  "wnli_val_interval": 100,
  "word_embs": "scratch"
}

Todo:
-Write tests for the parse_diff and json diff functions. 
-Test on more types of configuration changes. 