### PR TITLE
Fixing CommitmentBank Relative Path

### DIFF
--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -2169,7 +2169,7 @@ class SpanClassificationTask(Task):
         return metrics
 
 
-@register_task("commitbank", rel_path="CommitmentBank/")
+@register_task("commitbank", rel_path="CB/")
 class CommitmentTask(PairClassificationTask):
     """ NLI-formatted task detecting speaker commitment.
     Data and more info at github.com/mcdm/CommitmentBank/


### PR DESCRIPTION
Fixing the relative path that the src/tasks/tasks reads from to match the directory the downloader downloads CB data to. 
Fix for  #713 