### PR TITLE
Adding Separate Best Checkpoints for Target Train tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,13 +137,16 @@ def setup_target_task_training(args, target_tasks, model, strict):
                 # We want to do target training without pretraining, thus
                 # we need to first create a checkpoint to come back to for each of
                 # the target tasks to finetune.
-                assert_for_log(
-                    args.allow_untrained_encoder_parameters, "No best checkpoint found to evaluate."
-                )
                 model_state = model.state_dict()
                 model_path = os.path.join(args.run_dir, "model_state_untrained_pre_target_train.th")
                 torch.save(model_state, model_path)
-            log.warning("Using untrained encoder parameters!")
+            else:
+                # If do_pretrain = 0 and transfer_paradigm=frozen, then do_eval will evaluate on 
+                # untrained encoder parameters.
+                assert_for_log(
+                    args.allow_untrained_encoder_parameters, "No best checkpoint found to evaluate."
+                )  
+                log.warning("Using untrained encoder parameters!")
     return task_names_to_avoid_loading
 
 

--- a/main.py
+++ b/main.py
@@ -488,7 +488,7 @@ def main(cl_arguments):
             if args.transfer_paradigm == "finetune":
                 # Reload the original best model from before target-task
                 # training since we specifically finetune for each task.
-                pre_finetune_path = get_best_checkpoint_path(args.run_dir, "pretrain")
+                pre_target_train = get_best_checkpoint_path(args.run_dir, "pretrain")
 
                 load_model_state(
                     model, pre_target_train, args.cuda, skip_task_models=[], strict=strict
@@ -529,7 +529,7 @@ def main(cl_arguments):
                         phase = "pretrain"
                     else:
                         phase = "target_train"
-                    # find the task-specific best checkpoint to evaluat eon
+                    # Find the task-specific best checkpoint to evaluate on.
                     ckpt_path = get_best_checkpoint_path(args.run_dir, phase, task.name)
 
                 assert "best" in ckpt_path

--- a/main.py
+++ b/main.py
@@ -464,9 +464,6 @@ def main(cl_arguments):
                 task.val_metric_decreases,
                 phase="target_train",
             )
-            import pdb
-
-            pdb.set_trace()
             _ = trainer.train(
                 tasks=[task],
                 stop_metric=task.val_metric,

--- a/main.py
+++ b/main.py
@@ -141,11 +141,11 @@ def setup_target_task_training(args, target_tasks, model, strict):
                 model_path = os.path.join(args.run_dir, "model_state_untrained_pre_target_train.th")
                 torch.save(model_state, model_path)
             else:
-                # If do_pretrain = 0 and transfer_paradigm=frozen, then do_eval will evaluate on 
+                # If do_pretrain = 0 and transfer_paradigm=frozen, then do_eval will evaluate on
                 # untrained encoder parameters.
                 assert_for_log(
                     args.allow_untrained_encoder_parameters, "No best checkpoint found to evaluate."
-                )  
+                )
                 log.warning("Using untrained encoder parameters!")
     return task_names_to_avoid_loading
 
@@ -544,7 +544,9 @@ def main(cl_arguments):
                 for task in pretrain_tasks:
                     ckpt_path = get_best_checkpoint_path(args.run_dir, "pretrain", task.name)
                     assert ".best" in ckpt_path
-                    load_model_state(model, ckpt_path, args.cuda, skip_task_models=[], strict=strict)
+                    load_model_state(
+                        model, ckpt_path, args.cuda, skip_task_models=[], strict=strict
+                    )
                     evaluate_and_write(args, model, [task], splits_to_write)
 
         elif args.transfer_paradigm == "frozen":

--- a/main.py
+++ b/main.py
@@ -258,12 +258,12 @@ def get_best_checkpoint_path(run_dir, phase, task_name=None):
     if phase == "target_train":
         assert task_name is not None, "Specify a task checkpoint to evaluate from."
         checkpoint = glob.glob(
-            os.path.join(run_dir, task_name, "model_state_%s_epoch_*.best_macro.th" % phase)
+            os.path.join(run_dir, task_name, "model_state_%s_epoch_*.best.th" % phase)
         )
     if len(checkpoint) == 0:
         checkpoint = glob.glob(os.path.join(run_dir, "model_state_untrained_pre_target_train.th"))
     if len(checkpoint) == 0 and phase == "pretrain":
-        checkpoint = glob.glob(os.path.join(run_dir, "model_state_pretrain_epoch_*.best_macro.th"))
+        checkpoint = glob.glob(os.path.join(run_dir, "model_state_pretrain_epoch_*.best.th"))
     if len(checkpoint) > 0:
         assert_for_log(len(checkpoint) == 1, "Too many best checkpoints. Something is wrong.")
         return checkpoint[0]
@@ -489,7 +489,6 @@ def main(cl_arguments):
                 # Reload the original best model from before target-task
                 # training since we specifically finetune for each task.
                 pre_target_train = get_best_checkpoint_path(args.run_dir, "pretrain")
-
                 load_model_state(
                     model, pre_target_train, args.cuda, skip_task_models=[], strict=strict
                 )

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -304,10 +304,10 @@ class SamplingMultiTaskTrainer:
         for task in tasks:
             task_info = task_infos[task.name]
             if (
-                os.path.exists(self._serialization_dir + "/" + task.name) is False
+                os.path.exists(os.path.join(self._serialization_dir, task.name)) is False
                 and phase == "target_train"
             ):
-                os.mkdir(self._serialization_dir + "/" + task.name)
+                os.mkdir(os.path.join(self._serialization_dir, task.name))
 
             # Adding task-specific smart iterator to speed up training
             instance = [i for i in itertools.islice(task.train_data, 1)][0]
@@ -1041,7 +1041,7 @@ class SamplingMultiTaskTrainer:
         for file in candidates:
             # Skip the best, because we'll need it.
             # Skip the just-written checkpoint.
-            if "best" not in file and "_{}.".format(epoch) not in file:
+            if ".best" not in file and "_{}.".format(epoch) not in file:
                 os.remove(file)
 
     def _save_checkpoint(self, training_state, phase="pretrain", new_best_macro=False):
@@ -1050,8 +1050,6 @@ class SamplingMultiTaskTrainer:
         ----------
         training_state: An object containing trainer state (step number, etc.), to be saved.
         phase: Usually 'pretrain' or 'target_train'.
-        all_val_metrics If this is not none, then we loop through and save each task's _best 
-        in addiiton to the other checkpoints. 
         new_best_macro: If true, the saved checkpoint will be marked with .best_macro, and
             potentially used later when switching from pretraining to target task training.
         """

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -1077,7 +1077,7 @@ class SamplingMultiTaskTrainer:
             best_str = ".best_macro"
         else:
             best_str = ""
-        # save the overall best model for this target train in terms of macro/micro_avg score.
+        # Save the overall best model for this target train in terms of macro/micro_avg score.
         model_path = os.path.join(
             self._serialization_dir, "model_state_{}_epoch_{}{}.th".format(phase, epoch, best_str)
         )
@@ -1139,7 +1139,7 @@ class SamplingMultiTaskTrainer:
         )
         log.info("Saved general checkpoints to %s", self._serialization_dir)
 
-        # for each of the tasks, we update the best task-speciic checkpoints
+        # For each of the tasks, we update the best task-speciic checkpoints
         # only for target training.
         if phase == "target_train":
             self.save_task_specific_checkpoints(epoch, phase, task_states, model_state)

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -359,7 +359,7 @@ class SamplingMultiTaskTrainer:
         metric_infos = {
             metric: {"hist": [], "stopped": False, "best": (-1, {})} for metric in all_metrics
         }
-        self.task_to_metric_mapping = {task.val_metric: task.name}
+        self.task_to_metric_mapping = {task.val_metric: task.name for task in tasks}
         self._task_infos = task_infos
         self._metric_infos = metric_infos
         return task_infos, metric_infos
@@ -1151,7 +1151,7 @@ class SamplingMultiTaskTrainer:
         else:  # phase == "target_train":
             # For target train, we save a separate copy of BERT per task.
             self._save_target_train_checkpoints(
-                epoch, best_str, new_best_macro, task_states, model_state
+                epoch, best_str, new_best_macro, task_states, model_state, training_state
             )
 
         if not self._keep_all_checkpoints:
@@ -1160,7 +1160,7 @@ class SamplingMultiTaskTrainer:
         log.info("Saved checkpoints to %s", self._serialization_dir)
 
     def _save_target_train_checkpoints(
-        self, epoch, best_str, new_best_macro, task_states, model_state
+        self, epoch, best_str, new_best_macro, task_states, model_state, training_state
     ):
         """
         Saves task specific checkpoints. If transfer_paradigm=finetune, then each task-specific checkpoint 
@@ -1198,6 +1198,14 @@ class SamplingMultiTaskTrainer:
                     self._serialization_dir,
                     task_name,
                     "task_state_target_train_epoch_{}{}.th".format(epoch, best_str),
+                ),
+            )
+            torch.save(
+                training_state,
+                os.path.join(
+                    self._serialization_dir,
+                    task_name,
+                    "training_state_target_train_epoch_{}{}.th".format(epoch, best_str),
                 ),
             )
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -91,7 +91,7 @@ class TestCheckpionting(unittest.TestCase):
         self.args.exp_dir = ""
 
     @mock.patch("src.trainer.build_trainer_params", side_effect=build_trainer_params)
-    def test_checkpointing_does_run(self, build_trainer_params_function):
+    def test_target_train_checkpointing_does_run(self, build_trainer_params_function):
         # check that checkpointing does run and does sanity checks that at each step
         # it saves the most recent checkpoint as well as the best checkpoint.
         with mock.patch("src.models.MultiTaskModel") as MockModel:
@@ -175,6 +175,7 @@ class TestCheckpionting(unittest.TestCase):
             )
             from allennlp.common.params import Params
 
+            test_trainer.task_to_metric_mapping = {self.wic.val_metric: self.wic.name}
             test_trainer._task_infos = _task_infos
             test_trainer._metric_infos = _metric_infos
             test_trainer._g_optimizer = g_optimizer
@@ -191,11 +192,14 @@ class TestCheckpionting(unittest.TestCase):
                 new_best_macro=False,
             )
             assert os.path.exists(
-                self.temp_dir + "/model_state_target_train_epoch_1.best_macro.th"
-            ) and os.path.exists(self.temp_dir + "/model_state_target_train_epoch_2.th")
+                os.path.join(
+                    self.temp_dir, self.wic.name, "model_state_target_train_epoch_1.best_macro.th"
+                )
+            ) and os.path.exists(
+                os.path.join(self.temp_dir, self.wic.name, "/model_state_target_train_epoch_2.th")
+            )
 
         def does_produce_correct_demo_results(self):
             file_path = "~/repo/sample_run/jiant-demo/results.tsv"
             file = open(file_path, "rb")
-            print(file)
             assert file

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -17,6 +17,7 @@ from allennlp.data.iterators import BasicIterator, BucketIterator
 from allennlp.training.learning_rate_schedulers import (  # pylint: disable=import-error
     LearningRateScheduler,
 )
+from allennlp.common.params import Params
 from allennlp.training.optimizers import Optimizer
 from ..allennlp_mods.numeric_field import NumericField
 
@@ -167,7 +168,7 @@ class TestCheckpionting(unittest.TestCase):
             MockModel.return_value.named_parameters.return_value = [("model1", MockParams(True))]
             MockModel.use_bert = 1
             model = MockModel()
-            test_trainer, train_params, opt_params, schd_params = trainer.build_trainer(
+            pt_trainer, _, _, _ = trainer.build_trainer(
                 self.args,
                 ["wic"],  # here, we use WIC twice to reduce the amount of boiler-plate code
                 model,
@@ -176,7 +177,7 @@ class TestCheckpionting(unittest.TestCase):
                 phase="pretrain",
             )
 
-            test_trainer, train_params, opt_params, schd_params = trainer.build_trainer(
+            tt_trainer, _, _, _ = trainer.build_trainer(
                 self.args,
                 ["wic"],
                 model,
@@ -185,26 +186,29 @@ class TestCheckpionting(unittest.TestCase):
                 phase="target_train",
             )
             os.mkdir(os.path.join(self.temp_dir, "wic"))
-            from allennlp.common.params import Params
 
-            test_trainer.task_to_metric_mapping = {self.wic.val_metric: self.wic.name}
-            test_trainer._task_infos = _task_infos
-            test_trainer._metric_infos = _metric_infos
-            test_trainer._g_optimizer = g_optimizer
-            test_trainer._g_scheduler = g_scheduler
-            test_trainer._save_checkpoint(
+            tt_trainer.task_to_metric_mapping = {self.wic.val_metric: self.wic.name}
+            pt_trainer._task_infos = _task_infos
+            pt_trainer._metric_infos = _metric_infos
+            pt_trainer._g_optimizer = g_optimizer
+            pt_trainer._g_scheduler = g_scheduler
+            pt_trainer._save_checkpoint(
                 {"pass": 10, "epoch": 1, "should_stop": 0}, phase="pretrain", new_best_macro=True
             )
-            test_trainer._save_checkpoint(
+            pt_trainer._save_checkpoint(
                 {"pass": 10, "epoch": 2, "should_stop": 0}, phase="pretrain", new_best_macro=True
             )
+            tt_trainer._task_infos = _task_infos
+            tt_trainer._metric_infos = _metric_infos
+            tt_trainer._g_optimizer = g_optimizer
+            tt_trainer._g_scheduler = g_scheduler
 
-            test_trainer._save_checkpoint(
+            tt_trainer._save_checkpoint(
                 {"pass": 10, "epoch": 1, "should_stop": 0},
                 phase="target_train",
                 new_best_macro=True,
             )
-            test_trainer._save_checkpoint(
+            tt_trainer._save_checkpoint(
                 {"pass": 10, "epoch": 2, "should_stop": 0},
                 phase="target_train",
                 new_best_macro=False,

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -173,6 +173,7 @@ class TestCheckpionting(unittest.TestCase):
                 self.wic.val_metric_decreases,
                 phase="target_train",
             )
+            os.mkdir(os.path.join(self.temp_dir, "wic"))
             from allennlp.common.params import Params
 
             test_trainer.task_to_metric_mapping = {self.wic.val_metric: self.wic.name}
@@ -193,10 +194,10 @@ class TestCheckpionting(unittest.TestCase):
             )
             assert os.path.exists(
                 os.path.join(
-                    self.temp_dir, self.wic.name, "model_state_target_train_epoch_1.best_macro.th"
+                    self.temp_dir, "wic", "model_state_target_train_epoch_1.best.th"
                 )
             ) and os.path.exists(
-                os.path.join(self.temp_dir, self.wic.name, "/model_state_target_train_epoch_2.th")
+                os.path.join(self.temp_dir, "wic","model_state_target_train_epoch_2.th")
             )
 
         def does_produce_correct_demo_results(self):

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -7,6 +7,7 @@ import unittest
 from unittest import mock
 import torch
 import pandas as pd
+import glob
 
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.data import Instance, Token, vocabulary
@@ -91,9 +92,10 @@ class TestCheckpionting(unittest.TestCase):
         self.args.exp_dir = ""
 
     @mock.patch("src.trainer.build_trainer_params", side_effect=build_trainer_params)
-    def test_target_train_checkpointing_does_run(self, build_trainer_params_function):
-        # check that checkpointing does run and does sanity checks that at each step
-        # it saves the most recent checkpoint as well as the best checkpoint.
+    def test_checkpointing_does_run(self, build_trainer_params_function):
+        # Check that checkpointing does run and does sanity checks that at each step
+        # it saves the most recent checkpoint as well as the best checkpoint
+        # correctly for both pretrain and target_train stages.
         with mock.patch("src.models.MultiTaskModel") as MockModel:
             import torch
             import copy
@@ -220,7 +222,13 @@ class TestCheckpionting(unittest.TestCase):
                 and os.path.exists(os.path.join(self.temp_dir, "model_state_pretrain_epoch_1.th"))
             )
 
-        def does_produce_correct_demo_results(self):
+            # Assert only one checkpoint is created for pretrain stage.
+            pretrain_best_checkpoints = glob.glob(
+                os.path.join(self.temp_dir, "model_state_pretrain_epoch_*.best.th")
+            )
+            assert len(pretrain_best_checkpoints) == 1
+
+        def test_does_produce_results(self):
             file_path = "~/repo/sample_run/jiant-demo/results.tsv"
             file = open(file_path, "rb")
             assert file

--- a/tutorials/setup_tutorial.md
+++ b/tutorials/setup_tutorial.md
@@ -241,7 +241,7 @@ You should see something like this:
 After running this experiment, you should have in your run directory:
 
 * a checkpoint of the best model state (based on your scores)
-* a `log.log` file which contains all the logs
+* a directory for each of the target_tasks containing the checkpoints of the model, task, and training state of the best performing model parameters for that task.   
 * `params.conf` (a saved version of the parameters used)
 * written predictions for test for each of the target trained tasks (with file names `{task_name}-test.tsv`)
 * a saved checkpoint of your best validation metric.

--- a/tutorials/setup_tutorial.md
+++ b/tutorials/setup_tutorial.md
@@ -241,7 +241,8 @@ You should see something like this:
 After running this experiment, you should have in your run directory:
 
 * a checkpoint of the best model state (based on your scores)
-* a directory for each of the target_tasks containing the checkpoints of the model, task, and training state of the best performing model parameters for that task.   
+* a `log.log` file which contains all the logs
+* a directory for each of the target_tasks containing the checkpoints of the model, task, and training state of the finetuned BERT models for that task.
 * `params.conf` (a saved version of the parameters used)
 * written predictions for test for each of the target trained tasks (with file names `{task_name}-test.tsv`)
 * a saved checkpoint of your best validation metric.


### PR DESCRIPTION
Changes:
In target task training, we no longer keep only one checkpoint path - instead, for each target task, we store in separate directories. This applies to both transfer_paradigm=frozen and finetune. 

For pretraining, we still save the checkpoints in the run_dir directory - pretraining checkpoints should not be affected by this PR. 