### PR TITLE
Update to ntlk download instructions

### DIFF
--- a/tutorials/setup_tutorial.md
+++ b/tutorials/setup_tutorial.md
@@ -37,7 +37,7 @@ Some requirements may only be needed for specific configurations. If you have tr
 You will also need to install dependencies for `nltk` if you do not already have them:
 
 ```
-python -m nltk.downloader -d  perluniprops nonbreaking_prefixes punkt
+nltk.downloader -d ./nltk_data  perluniprops nonbreaking_prefixes punkt
 ```
 
 


### PR DESCRIPTION
This matches what's done in Dockerfile in specifying a target directory, and seems to be more robust. Should fix #744.