### PR TITLE
WSC cuda fix

### DIFF
--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -2548,7 +2548,9 @@ class WinogradCoreferenceTask(SpanClassificationTask):
             Returns:
             one hot encoding of size [batch_size, 2]
             """
-            ones = torch.sparse.torch.eye(depth).cuda()
+            ones = torch.sparse.torch.eye(depth)
+            if torch.cuda.is_available():
+                ones = ones.cuda()
             return ones.index_select(0, batch)
 
         binary_preds = make_one_hot(logits, depth=2)


### PR DESCRIPTION
Meant to fix the second half of #773.

I'm not sure if this is necessary—it may be safe to just delete this entirely and trust that PyTorch will move this over when it moves over the rest of the model. In any case, though, raw cuda() calls break CPU machine support. 

@pruksmhc, you wrote this part—any ideas?