### PR TITLE
Fixing labels for WSC

### DIFF
--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -2535,7 +2535,7 @@ class WinogradCoreferenceTask(SpanClassificationTask):
         self._iters_by_split = iters_by_split
 
     def get_all_labels(self):
-        return ["True", "False"]
+        return ["False", "True"]
 
     def update_metrics(self, logits, labels, tagmask=None):
         logits, labels = logits.detach(), labels.detach()


### PR DESCRIPTION
In the current version of WSC, the labels were being switched ("False"in the dataset was being mapped to 1, and "True" to 0). This PR fixes it. 