### PR TITLE
Pool type

### DIFF
--- a/config/ccg_bert.conf
+++ b/config/ccg_bert.conf
@@ -16,6 +16,7 @@ skip_embs = 1
 
 // BERT-specific setup
 classifier = log_reg // following BERT paper
+pool_type = first
 
 dropout = 0.1 // following BERT paper
 optimizer = bert_adam

--- a/config/copa_bert.conf
+++ b/config/copa_bert.conf
@@ -22,6 +22,7 @@ input_module = bert-base-uncased
 tokenizer = bert-base-uncased
 transfer_paradigm = finetune
 classifier = log_reg
+pool_type = first
 optimizer = bert_adam
 lr = 0.00001
 sent_enc = none

--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -342,6 +342,8 @@ pair_attn = 1  // If true, use attn in sentence-pair classification/regression t
 d_hid_attn = 512  // Post-attention LSTM state size.
 shared_pair_attn = 0  // If true, share pair_attn parameters across all tasks that use it.
 d_proj = 512  // Size of task-specific linear projection applied before before pooling.
+pool_type = "max" // Type of pooling to reduce sequences of vectors into a single vector.
+                  // Options: "max", "mean", "first", "final"
 span_classifier_loss_fn = "softmax"  // Classifier loss function. Used only in some tasks (notably
                                      // span-related tasks), not mlp/fancy_mlp. Currently supports
                                      // sigmoid and softmax.

--- a/config/examples/copa_bert.conf
+++ b/config/examples/copa_bert.conf
@@ -22,6 +22,7 @@ input_module = bert-base-uncased
 tokenizer = bert-base-uncased
 transfer_paradigm = finetune
 classifier = log_reg
+pool_type = first
 optimizer = bert_adam
 lr = 0.00001
 sent_enc = none

--- a/config/examples/stilts_example.conf
+++ b/config/examples/stilts_example.conf
@@ -19,6 +19,7 @@ write_preds = "val,test"
 
 //BERT-specific parameters
 bert_embeddings_mode = "top"
+pool_type = "first"
 sep_embs_for_skip = 1
 sent_enc = "none"
 classifier = log_reg // following BERT paper

--- a/config/superglue-bert.conf
+++ b/config/superglue-bert.conf
@@ -11,6 +11,7 @@ tokenizer = "bert-large-cased"
 // Model settings
 input_module = "bert-large-cased"
 bert_embeddings_mode = "top"
+pool_type = "first"
 pair_attn = 0 // shouldn't be needed but JIC
 s2s = {
     attention = none

--- a/main.py
+++ b/main.py
@@ -473,7 +473,6 @@ def main(cl_arguments):
     start_time = time.time()
     model = build_model(args, vocab, word_embs, tasks)
     log.info("Finished building model in %.3fs", time.time() - start_time)
-    import ipdb; ipdb.set_trace()
 
     # Start Tensorboard if requested
     if cl_args.tensorboard:

--- a/main.py
+++ b/main.py
@@ -473,6 +473,7 @@ def main(cl_arguments):
     start_time = time.time()
     model = build_model(args, vocab, word_embs, tasks)
     log.info("Finished building model in %.3fs", time.time() - start_time)
+    import ipdb; ipdb.set_trace()
 
     # Start Tensorboard if requested
     if cl_args.tensorboard:

--- a/src/models.py
+++ b/src/models.py
@@ -574,9 +574,7 @@ def build_single_sentence_module(task, d_inp: int, use_bert: bool, params: Param
     args:
         - task (Task): task object, used to get the number of output classes
         - d_inp (int): input dimension to the module, needed for optional linear projection
-        - use_bert (bool): if using BERT, extract the first vector from the inputted
-            sequence, rather than max pooling. We do this for BERT specifically to follow
-            the convention set in the paper (Devlin et al., 2019).
+        - use_bert (bool): if using BERT, skip projection before pooling.
         - params (Params): Params object with task-specific parameters
 
     returns:

--- a/src/models.py
+++ b/src/models.py
@@ -537,6 +537,7 @@ def get_task_specific_params(args, task_name):
     params = {}
     params["cls_type"] = _get_task_attr("classifier")
     params["d_hid"] = _get_task_attr("classifier_hid_dim")
+    params["pool_type"] = _get_task_attr("pool_type")
     params["d_proj"] = _get_task_attr("d_proj")
     params["shared_pair_attn"] = args.shared_pair_attn
     if args.shared_pair_attn:
@@ -582,8 +583,7 @@ def build_single_sentence_module(task, d_inp: int, use_bert: bool, params: Param
         - SingleClassifier (nn.Module): single-sentence classifier consisting of
             (optional) a linear projection, pooling, and an MLP classifier
     """
-    pool_type = "first" if use_bert else "max"
-    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=pool_type)
+    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"])
     d_out = d_inp if use_bert else params["d_proj"]
     classifier = Classifier.from_params(d_out, task.n_classes, params)
     module = SingleClassifier(pooler, classifier)
@@ -615,9 +615,8 @@ def build_pair_sentence_module(task, d_inp, model, params):
         pooler = Pooler(project=False, d_inp=params["d_hid_attn"], d_proj=params["d_hid_attn"])
         d_out = params["d_hid_attn"] * 2
     else:
-        pool_type = "first" if model.use_bert else "max"
         pooler = Pooler(
-            project=not model.use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=pool_type
+            project=not model.use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"]
         )
         d_out = d_inp if model.use_bert else params["d_proj"]
 
@@ -668,9 +667,8 @@ def build_tagger(task, d_inp, out_dim):
 
 def build_multiple_choice_module(task, d_sent, use_bert, params):
     """ Basic parts for MC task: reduce a vector representation for each model into a scalar. """
-    pool_type = "first" if use_bert else "max"
     pooler = Pooler(
-        project=not use_bert, d_inp=d_sent, d_proj=params["d_proj"], pool_type=pool_type
+        project=not use_bert, d_inp=d_sent, d_proj=params["d_proj"], pool_type=params["pool_type"]
     )
     d_out = d_sent if use_bert else params["d_proj"]
     choice2scalar = Classifier(d_out, n_classes=1, cls_type=params["cls_type"])
@@ -701,8 +699,7 @@ def build_qa_module(task, d_inp, use_bert, params):
     3) classifier
 
     This module models each question-answer pair _individually_ """
-    pool_type = "first" if use_bert else "max"
-    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=pool_type)
+    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"])
     d_out = d_inp if use_bert else params["d_proj"]
     classifier = Classifier.from_params(d_out, 2, params)
     return SingleClassifier(pooler, classifier)

--- a/src/models.py
+++ b/src/models.py
@@ -583,7 +583,9 @@ def build_single_sentence_module(task, d_inp: int, use_bert: bool, params: Param
         - SingleClassifier (nn.Module): single-sentence classifier consisting of
             (optional) a linear projection, pooling, and an MLP classifier
     """
-    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"])
+    pooler = Pooler(
+        project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"]
+    )
     d_out = d_inp if use_bert else params["d_proj"]
     classifier = Classifier.from_params(d_out, task.n_classes, params)
     module = SingleClassifier(pooler, classifier)
@@ -616,7 +618,10 @@ def build_pair_sentence_module(task, d_inp, model, params):
         d_out = params["d_hid_attn"] * 2
     else:
         pooler = Pooler(
-            project=not model.use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"]
+            project=not model.use_bert,
+            d_inp=d_inp,
+            d_proj=params["d_proj"],
+            pool_type=params["pool_type"],
         )
         d_out = d_inp if model.use_bert else params["d_proj"]
 
@@ -699,7 +704,9 @@ def build_qa_module(task, d_inp, use_bert, params):
     3) classifier
 
     This module models each question-answer pair _individually_ """
-    pooler = Pooler(project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"])
+    pooler = Pooler(
+        project=not use_bert, d_inp=d_inp, d_proj=params["d_proj"], pool_type=params["pool_type"]
+    )
     d_out = d_inp if use_bert else params["d_proj"]
     classifier = Classifier.from_params(d_out, 2, params)
     return SingleClassifier(pooler, classifier)

--- a/src/modules/simple_modules.py
+++ b/src/modules/simple_modules.py
@@ -40,7 +40,7 @@ class Pooler(nn.Module):
             seq_emb = proj_seq.sum(dim=1) / mask.sum(dim=1)
         elif self.pool_type == "final":
             idxs = mask.expand_as(proj_seq).sum(dim=1, keepdim=True).long() - 1
-            seq_emb = proj_seq.gather(dim=1, index=idxs)
+            seq_emb = proj_seq.gather(dim=1, index=idxs).squeeze(dim=1)
         elif self.pool_type == "first":
             seq_emb = proj_seq[:, 0]
         return seq_emb


### PR DESCRIPTION
Addresses #631 and #532 .

Exposes `pool_type` as a cmdline arg and uses it in model construction. Note that for BERT runs, we now need to manually specify `first` pooling. This commit also adds it to BERT configs.