### PR TITLE
Fix wsc labels

### DIFF
--- a/jiant/evaluate.py
+++ b/jiant/evaluate.py
@@ -324,7 +324,7 @@ def _write_winograd_preds(
     with open(preds_file, "w", encoding="utf-8") as preds_fh:
         for row_idx, row in preds_df.iterrows():
             if strict_glue_format:
-                out_d = {"idx": row["idx"], "label": pred_map[row["preds"]]}
+                out_d = {"idx": int(row["idx"]), "label": pred_map[row["preds"]]}
             else:
                 out_d = row.to_dict()
             preds_fh.write("{0}\n".format(json.dumps(out_d)))

--- a/jiant/modules/span_modules.py
+++ b/jiant/modules/span_modules.py
@@ -179,8 +179,7 @@ class SpanClassifierModule(nn.Module):
         if self.loss_type == "sigmoid":
             return F.binary_cross_entropy(torch.sigmoid(logits), labels.float())
         elif self.loss_type == "softmax":
-            targets = (labels == 1).nonzero()[:, 1]
-            return F.cross_entropy(logits, targets.long())
+            return F.cross_entropy(logits, labels.long())
         else:
             raise ValueError(
                 "Unsupported loss type '%s' " "for span classification." % self.loss_type

--- a/jiant/modules/span_modules.py
+++ b/jiant/modules/span_modules.py
@@ -130,10 +130,10 @@ class SpanClassifierModule(nn.Module):
         # Compute loss if requested.
         if "labels" in batch:
             logits = logits.squeeze(dim=1)
-            out["loss"] = self.compute_loss(logits, batch["labels"].squeeze(dim=1), task)
+            out["loss"] = self.compute_loss(logits, batch["labels"], task)
             predictions = self.get_predictions(logits)
             tagmask = batch.get("tagmask", None)
-            task.update_metrics(predictions, batch["labels"].squeeze(dim=1), tagmask=tagmask)
+            task.update_metrics(predictions, batch["labels"], tagmask=tagmask)
 
         if predict:
             # Return preds as a list.

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -2340,9 +2340,10 @@ class SpanClassificationTask(Task):
         example["labels"] = ListField(
             [
                 MultiLabelField(
-                    [str(record["label"])],
+                    [record["label"]],
                     label_namespace=self._label_namespace,
-                    skip_indexing=False,
+                    skip_indexing=True,
+                    num_labels=self.n_classes,
                 )
             ]
         )
@@ -2753,11 +2754,10 @@ class WinogradCoreferenceTask(SpanClassificationTask):
                     self.tokenizer_name, filename, has_labels=False
                 )
             else:
-                iters_by_split[split] = load_span_data(self.tokenizer_name, filename)
+                iters_by_split[split] = load_span_data(
+                    self.tokenizer_name, filename, label_fn=lambda x: 0 if x is False else 1
+                )
         self._iters_by_split = iters_by_split
-
-    def get_all_labels(self):
-        return ["False", "True"]
 
     def update_metrics(self, logits, labels, tagmask=None):
         logits, labels = logits.detach(), labels.detach()

--- a/jiant/utils/data_loaders.py
+++ b/jiant/utils/data_loaders.py
@@ -40,10 +40,9 @@ def load_span_data(tokenizer_name, file_name, label_fn=None, has_labels=True):
     # realign spans
     rows = rows.apply(lambda x: realign_spans(x, tokenizer_name), axis=1)
     if has_labels is False:
-        rows["label"] = False
-    else:
-        if label_fn is not None:
-            rows["label"] = rows["label"].apply(lambda x: label_fn(x))
+        rows["label"] = 0
+    elif label_fn is not None:
+        rows["label"] = rows["label"].apply(label_fn)
     return list(rows.T.to_dict().values())
 
 

--- a/jiant/utils/data_loaders.py
+++ b/jiant/utils/data_loaders.py
@@ -41,6 +41,9 @@ def load_span_data(tokenizer_name, file_name, label_fn=None, has_labels=True):
     rows = rows.apply(lambda x: realign_spans(x, tokenizer_name), axis=1)
     if has_labels is False:
         rows["label"] = False
+    else:
+        if label_fin is not None:
+            rows["label"] = rows["label"].apply(lambda x: label_fn(x))
     return list(rows.T.to_dict().values())
 
 

--- a/jiant/utils/data_loaders.py
+++ b/jiant/utils/data_loaders.py
@@ -42,7 +42,7 @@ def load_span_data(tokenizer_name, file_name, label_fn=None, has_labels=True):
     if has_labels is False:
         rows["label"] = False
     else:
-        if label_fin is not None:
+        if label_fn is not None:
             rows["label"] = rows["label"].apply(lambda x: label_fn(x))
     return list(rows.T.to_dict().values())
 

--- a/scripts/download_superglue_data.py
+++ b/scripts/download_superglue_data.py
@@ -78,11 +78,7 @@ def get_tasks(task_names):
 def main(arguments):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-d",
-        "--data_dir",
-        help="directory to save data to",
-        type=str,
-        default="../superglue_data",
+        "-d", "--data_dir", help="directory to save data to", type=str, default="../superglue_data"
     )
     parser.add_argument(
         "-t",


### PR DESCRIPTION
Currently, WSC labels are being loaded via the get_all_labels() function, which is mapping the labels to integers. However, this is causing complications when running a non-WSC baseline, followed by the WSC baseline, due to some naming errors. 
Here, we implement a more standard flow for preprocesisng abels. 