### PR TITLE
Fix edge probing at head

### DIFF
--- a/jiant/tasks/edge_probing.py
+++ b/jiant/tasks/edge_probing.py
@@ -91,8 +91,7 @@ class EdgeProbingTask(Task):
         self.single_sided = single_sided
 
         self._iters_by_split = None  # see self.load_data()
-        self.all_labels = list(utils.load_lines(
-            os.path.join(self.path, label_file)))
+        self.all_labels = list(utils.load_lines(os.path.join(self.path, label_file)))
         self.n_classes = len(self.all_labels)
 
         # see add_task_label_namespace in preprocess.py
@@ -264,11 +263,7 @@ register_task(
     "edges-pos-ontonotes",
     rel_path="edges/ontonotes/const/pos",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "development.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "development.json", "test": "test.json"},
     single_sided=True,
 )(EdgeProbingTask)
 # Constituency labeling (nonterminals) on OntoNotes.
@@ -276,11 +271,7 @@ register_task(
     "edges-nonterminal-ontonotes",
     rel_path="edges/ontonotes/const/nonterminal",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "development.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "development.json", "test": "test.json"},
     single_sided=True,
 )(EdgeProbingTask)
 # Dependency edge labeling on English Web Treebank (UD).
@@ -300,11 +291,7 @@ register_task(
     "edges-ner-ontonotes",
     rel_path="edges/ontonotes/ner",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "development.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "development.json", "test": "test.json"},
     single_sided=True,
 )(EdgeProbingTask)
 # SRL CoNLL 2012 (OntoNotes), formulated as an edge-labeling task.
@@ -312,11 +299,7 @@ register_task(
     "edges-srl-conll2012",
     rel_path="edges/ontonotes/srl",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "development.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "development.json", "test": "test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 # Re-processed version of edges-coref-ontonotes, via AllenNLP data loaders.
@@ -324,11 +307,7 @@ register_task(
     "edges-coref-ontonotes-conll",
     rel_path="edges/ontonotes/coref",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "development.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "development.json", "test": "test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 # SPR1, as an edge-labeling task (multilabel).
@@ -336,11 +315,7 @@ register_task(
     "edges-spr1",
     rel_path="edges/spr1",
     label_file="labels.txt",
-    files_by_split={
-        "train": "spr1.train.json",
-        "val": "spr1.dev.json",
-        "test": "spr1.test.json"
-    },
+    files_by_split={"train": "spr1.train.json", "val": "spr1.dev.json", "test": "spr1.test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 # SPR2, as an edge-labeling task (multilabel).
@@ -360,11 +335,7 @@ register_task(
     "edges-dpr",
     rel_path="edges/dpr",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "dev.json",
-        "test": "test.json",
-    },
+    files_by_split={"train": "train.json", "val": "dev.json", "test": "test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 # Relation classification on SemEval 2010 Task8. 19 labels.
@@ -372,11 +343,7 @@ register_task(
     "edges-rel-semeval",
     rel_path="edges/semeval",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.0.85.json",
-        "val": "dev.json",
-        "test": "test.json"
-    },
+    files_by_split={"train": "train.0.85.json", "val": "dev.json", "test": "test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 
@@ -388,11 +355,7 @@ register_task(
     "edges-rel-tacred",
     rel_path="edges/tacred/rel",
     label_file="labels.txt",
-    files_by_split={
-        "train": "train.json",
-        "val": "dev.json",
-        "test": "test.json"
-    },
+    files_by_split={"train": "train.json", "val": "dev.json", "test": "test.json"},
     is_symmetric=False,
 )(EdgeProbingTask)
 

--- a/jiant/tasks/edge_probing.py
+++ b/jiant/tasks/edge_probing.py
@@ -86,13 +86,15 @@ class EdgeProbingTask(Task):
             for split, fname in files_by_split.items()
         }
         self.path = path
+        self.label_file = os.path.join(self.path, label_file)
         self.max_seq_len = max_seq_len
         self.is_symmetric = is_symmetric
         self.single_sided = single_sided
 
-        self._iters_by_split = None  # see self.load_data()
-        self.all_labels = list(utils.load_lines(os.path.join(self.path, label_file)))
-        self.n_classes = len(self.all_labels)
+        # Placeholders; see self.load_data()
+        self._iters_by_split = None
+        self.all_labels = None
+        self.n_classes = None
 
         # see add_task_label_namespace in preprocess.py
         self._label_namespace = self.name + "_labels"
@@ -151,6 +153,8 @@ class EdgeProbingTask(Task):
         return record
 
     def load_data(self):
+        self.all_labels = list(utils.load_lines(self.label_file))
+        self.n_classes = len(self.all_labels)
         iters_by_split = collections.OrderedDict()
         for split, filename in self._files_by_split.items():
             #  # Lazy-load using RepeatableIterator.

--- a/jiant/tasks/edge_probing.py
+++ b/jiant/tasks/edge_probing.py
@@ -267,24 +267,24 @@ class EdgeProbingTask(Task):
 # Part-of-Speech tagging on OntoNotes.
 register_task(
     "edges-pos-ontonotes",
-    rel_path="edges/ontonotes-constituents",
-    label_file="labels.pos.txt",
+    rel_path="edges/ontonotes/const/pos",
+    label_file="labels.txt",
     files_by_split={
-        "train": "consts_ontonotes_en_train.pos.json",
-        "val": "consts_ontonotes_en_dev.pos.json",
-        "test": "consts_ontonotes_en_test.pos.json",
+        "train": "train.json",
+        "val": "development.json",
+        "test": "test.json",
     },
     single_sided=True,
 )(EdgeProbingTask)
 # Constituency labeling (nonterminals) on OntoNotes.
 register_task(
     "edges-nonterminal-ontonotes",
-    rel_path="edges/ontonotes-constituents",
-    label_file="labels.nonterminal.txt",
+    rel_path="edges/ontonotes/const/nonterminal",
+    label_file="labels.txt",
     files_by_split={
-        "train": "consts_ontonotes_en_train.nonterminal.json",
-        "val": "consts_ontonotes_en_dev.nonterminal.json",
-        "test": "consts_ontonotes_en_test.nonterminal.json",
+        "train": "train.json",
+        "val": "development.json",
+        "test": "test.json",
     },
     single_sided=True,
 )(EdgeProbingTask)
@@ -294,45 +294,45 @@ register_task(
     rel_path="edges/dep_ewt",
     label_file="labels.txt",
     files_by_split={
-        "train": "train.edges.json",
-        "val": "dev.edges.json",
-        "test": "test.edges.json",
+        "train": "en_ewt-ud-train.json",
+        "val": "en_ewt-ud-dev.json",
+        "test": "en_ewt-ud-test.json",
     },
     is_symmetric=False,
 )(EdgeProbingTask)
 # Entity type labeling on OntoNotes.
 register_task(
     "edges-ner-ontonotes",
-    rel_path="edges/ontonotes-ner",
+    rel_path="edges/ontonotes/ner",
     label_file="labels.txt",
     files_by_split={
-        "train": "ner_ontonotes_en_train.json",
-        "val": "ner_ontonotes_en_dev.json",
-        "test": "ner_ontonotes_en_test.json",
+        "train": "train.json",
+        "val": "development.json",
+        "test": "test.json",
     },
     single_sided=True,
 )(EdgeProbingTask)
 # SRL CoNLL 2012 (OntoNotes), formulated as an edge-labeling task.
 register_task(
     "edges-srl-conll2012",
-    rel_path="edges/srl_conll2012",
+    rel_path="edges/ontonotes/srl",
     label_file="labels.txt",
     files_by_split={
-        "train": "train.edges.json",
-        "val": "dev.edges.json",
-        "test": "test.edges.json",
+        "train": "train.json",
+        "val": "development.json",
+        "test": "test.json",
     },
     is_symmetric=False,
 )(EdgeProbingTask)
 # Re-processed version of edges-coref-ontonotes, via AllenNLP data loaders.
 register_task(
     "edges-coref-ontonotes-conll",
-    rel_path="edges/ontonotes-coref-conll",
+    rel_path="edges/ontonotes/coref",
     label_file="labels.txt",
     files_by_split={
-        "train": "coref_conll_ontonotes_en_train.json",
-        "val": "coref_conll_ontonotes_en_dev.json",
-        "test": "coref_conll_ontonotes_en_test.json",
+        "train": "train.json",
+        "val": "development.json",
+        "test": "test.json",
     },
     is_symmetric=False,
 )(EdgeProbingTask)
@@ -373,7 +373,11 @@ register_task(
     "edges-rel-semeval",
     rel_path="edges/semeval",
     label_file="labels.txt",
-    files_by_split={"train": "train.0.85.json", "val": "dev.json", "test": "test.json"},
+    files_by_split={
+        "train": "train.0.85.json",
+        "val": "dev.json",
+        "test": "test.json"
+    },
     is_symmetric=False,
 )(EdgeProbingTask)
 
@@ -385,7 +389,11 @@ register_task(
     "edges-rel-tacred",
     rel_path="edges/tacred/rel",
     label_file="labels.txt",
-    files_by_split={"train": "train.json", "val": "dev.json", "test": "test.json"},
+    files_by_split={
+        "train": "train.json",
+        "val": "dev.json",
+        "test": "test.json"
+    },
     is_symmetric=False,
 )(EdgeProbingTask)
 


### PR DESCRIPTION
Fix a crash on task.get_all_labels() (due to a bad merge?), and fix data paths to match probing/get_and_process_all_data.sh.

TODOs:
- Verify numbers match the paper
- Clean up old tasks and unused code paths
- Get Kubernetes working