### PR TITLE
Add username to job name and project dir for Kubernetes runs

### DIFF
--- a/gcp/kubernetes/templates/jiant_env.libsonnet
+++ b/gcp/kubernetes/templates/jiant_env.libsonnet
@@ -10,6 +10,9 @@
   # Mount point for the NFS volume, as the container will see it.
   nfs_mount_path: "/nfs/jiant",
 
+  # Default experiment directory; must be writable by Kubernetes workers.
+  nfs_exp_dir: "/nfs/jiant/exp",
+
   # Name of pre-built Docker image, accessible from Kubernetes.
   gcr_image: "gcr.io/google.com/jiant-stilts/jiant-conda:v0",
 


### PR DESCRIPTION
Better default behavior on a multi-user cluster.