### PR TITLE
[WIP] Complete pytorch transformers interface, deprecate old GPT implement

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -237,16 +237,16 @@ input_module = ""  // The word embedding or contextual word representation layer
                    //   - elmo-chars-only: The dynamic CNN-based word embedding layer of AllenNLP's
                    //       ELMo, but not ELMo's LSTM layer hidden states. Use with
                    //       tokenizer = MosesTokenizer.
-                   //   - gpt: The OpenAI GPT language model encoder.
-                   //       Use with tokenizer = OpenAI.BPE.
-                   //   - bert-base-uncased, etc.: Any BERT model specifier that is valid for
-                   //       pytorch-pretrained-bert may be specified here. Use with
-                   //       tokenizer = ${input_module}
-                   //       We support the newer bert-large-uncased-whole-word-masking and
-                   //       bert-large-cased-whole-word-masking cased models, but they require
-                   //       the git development version of pytorch-pretrained-bert. To use these
-                   //       models, follow the instructions under 'From source' here:
-                   //         https://github.com/huggingface/pytorch-pretrained-BERT
+                   //   - openai-gpt: The OpenAI GPT language model encoder from
+                   //       pytorch_transformers.
+                   //   - gpt2 / gpt2-medium: The OpenAI GPT2 language model encoder from
+                   //       pytorch_transformers..
+                   //   - transfo-xl-wt103: The Transformer-XL model encoder from
+                   //       pytorch_transformers.
+                   //   - xlm-mlm-enfr-1024, etc.: Any XLM encoder from pytorch_transformers.
+                   //   - bert-base-uncased, etc.: Any BERT model from pytorch_transformers.
+                   // Note: Any input_module from pytorch_transformers requires 
+                   // tokenizer = ${input_module} or auto.
 
 tokenizer = auto  // The name of the tokenizer, passed to the Task constructor for
                   // appropriate handling during data loading. Currently supported
@@ -257,8 +257,7 @@ tokenizer = auto  // The name of the tokenizer, passed to the Task constructor f
                   //   - MosesTokenizer: Our standard word tokenizer. (Support for
                   //       other NLTK tokenizers is pending.)
                   //   - bert-uncased-base, etc.: Use the tokenizer supplied with
-                  //       pytorch-pretrained-bert that corresponds to that BERT model.
-                  //   - OpenAI.BPE: The tokenizer supplied with OpenAI GPT.
+                  //       pytorch_transformers that corresponds the input_module.
 
 word_embs_file = ${WORD_EMBS_FILE}  // Path to embeddings file, used with glove and fastText.
 d_word = 300  //  Dimension of word embeddings, used with scratch, glove, or fastText.
@@ -271,18 +270,6 @@ char_embs = 0  // Experimental. If true, train char embeddings. This is separate
 d_char = 100  // Dimension of trained char embeddings.
 n_char_filters = 100  // Number of filters in trained char CNN.
 char_filter_sizes = "2,3,4,5"  // Size of char CNN filters.
-
-openai_transformer_ckpt = ""  // If non-empty, will load OpenAI Transformer from the given
-                              // TensorFlow checkpoint. Checkpoint should be as created by the
-                              // original release (openai/finetune-transformer-lm).
-openai_embeddings_mode = "none"  // How to handle the embedding layer of the OpenAI Transformer
-                                 // model:
-                                 // "none" or "top" returns only top-layer activation,
-                                 // "cat" returns top-layer concatenated with
-                                 //   lexical layer,
-                                 // "only" returns only lexical layer,
-                                 // "mix" uses ELMo-style scalar mixing (with
-                                 //   learned weights) across all layers.
 
 pytorch_transformers_output_mode = "none"  // How to handle the embedding layer of the
                                            // BERT/XLNet model:


### PR DESCRIPTION
- Replacing old GPT implement with the one from huggingface pytorch transformers
- Add GPT2, Transformer-XL, XLM to pytorch transformer interface 
- Refactor pytorch transformer interface a little bit to reduce duplicated / outdated code & comments