### PR TITLE
MNLI hypothesis-only loading fix

### DIFF
--- a/jiant/config/defaults.conf
+++ b/jiant/config/defaults.conf
@@ -182,7 +182,6 @@ delete_checkpoints_when_done = 0  // If set, delete *all* saved checkpoints when
                                   // tests on any specific trained model. Will not apply if
                                   // keep_all_checkpoints is set.
 
-
 // Multi-task Training
 weighting_method = proportional  // Weighting method for task sampling, relative to the number of
                                  // training examples in each task:


### PR DESCRIPTION
The hypothesis-only MNLI task was broken by a merge error early in work on #884—it became a _premise_-only task, which is a lot less interesting. Fixing here.