### PR TITLE
Fixing index problem & minor pytorch_transformers_interface cleanup

### DIFF
--- a/jiant/preprocess.py
+++ b/jiant/preprocess.py
@@ -619,13 +619,6 @@ def add_pytorch_transformers_vocab(vocab, tokenizer_name):
 
     vocab_size = len(tokenizer)
     # do not use tokenizer.vocab_size, it does not include newly added token
-    if tokenizer_name.startswith("roberta-"):
-        if tokenizer.convert_ids_to_tokens(vocab_size - 1) is None:
-            vocab_size -= 1
-        else:
-            log.info("Time to delete vocab_size-1 in preprocess.py !!!")
-    # due to a quirk in huggingface's file, the last token of RobertaTokenizer is None, remove
-    # this when they fix the problem
 
     ordered_vocab = tokenizer.convert_ids_to_tokens(range(vocab_size))
     log.info("Added pytorch_transformers vocab (%s): %d tokens", tokenizer_name, len(ordered_vocab))


### PR DESCRIPTION
1. When task includes index pointing to a certain location in the input, the index is not adjusted w.r.t. the boundary function. So every input module from pytorch_transformer is not acting correctly on WiC.  And XLNet is not working correctly for WSC. Blimp & NPI pair do not suffer from the problem though. I added optional outputs that return the index offset when applying boundary tokens to sentences, so the index is correct now.

2. Huggingface fixed their vocab file problem, so I remove the code coping with that problem.

3. I found there were some tailing spaces in the docstrings of pytorch_transformers_interface, so I removed them.