### PR TITLE
replace correct_sent_indexing with non inplace version

### DIFF
--- a/jiant/pytorch_transformers_interface/modules.py
+++ b/jiant/pytorch_transformers_interface/modules.py
@@ -121,6 +121,7 @@ class PytorchTransformersEmbedderModule(nn.Module):
                 ids.size()[-1] <= self.max_pos
             ), "input length exceeds position embedding capacity, reduce max_seq_len"
 
+        sent[self.tokenizer_required] = ids
         return ids, input_mask
 
     def prepare_output(self, lex_seq, hidden_states, input_mask):

--- a/jiant/pytorch_transformers_interface/modules.py
+++ b/jiant/pytorch_transformers_interface/modules.py
@@ -113,10 +113,9 @@ class PytorchTransformersEmbedderModule(nn.Module):
             ids = (ids - 2) * valid_mask + self._pad_id * pad_mask + self._unk_id * unk_mask
         else:
             ids = (ids - 2) * valid_mask + self._pad_id * pad_mask
-
-        assert (
-            ids >= 0
-        ).all(), "out-of-vocabulary token found in the input, but _unk_id of pytorch_transformers model is not specified"
+            assert (
+                unk_mask == 0
+            ).all(), "out-of-vocabulary token found in the input, but _unk_id of pytorch_transformers model is not specified"
         if self.max_pos is not None:
             assert (
                 ids.size()[-1] <= self.max_pos


### PR DESCRIPTION
Previously, pytorch_transformers_interface uses inplace operation to adjust token index, this can cause problem when sent_enc is not "none".