### PR TITLE
Set _unk_id in Roberta module

### DIFF
--- a/jiant/pytorch_transformers_interface/modules.py
+++ b/jiant/pytorch_transformers_interface/modules.py
@@ -327,7 +327,7 @@ class RobertaEmbedderModule(PytorchTransformersEmbedderModule):
         self._sep_id = self.tokenizer.convert_tokens_to_ids("</s>")
         self._cls_id = self.tokenizer.convert_tokens_to_ids("<s>")
         self._pad_id = self.tokenizer.convert_tokens_to_ids("<pad>")
-        self._pad_id = self.tokenizer.convert_tokens_to_ids("<unk>")
+        self._unk_id = self.tokenizer.convert_tokens_to_ids("<unk>")
 
         self.parameter_setup(args)
 


### PR DESCRIPTION
Currently the `_unk_id` for Roberta is not set correctly, which triggers the assertion error on line 118.