### PR TITLE
Add a two-class variant of the MNLI task

### DIFF
--- a/jiant/metrics/nli_metrics.py
+++ b/jiant/metrics/nli_metrics.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+from overrides import overrides
+import torch
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("nli_two_class_accuracy")
+class NLITwoClassAccuracy(Metric):
+    """
+    Metric that evaluates two-way NLI classifiers on three-way data or vice-versa.
+
+    Thhis computes standard accuracy, but collapses 'neutral' and 'contradiction'
+    into one label, assuming that 'entailment' is at index 1 (as in the jiant
+    implementations of SNLI, MNLI and RTE).
+
+    Based on allennlp.training.metrics.CategoricalAccuracy.
+    """
+
+    def __init__(self) -> None:
+        self.correct_count = 0.0
+        self.total_count = 0.0
+
+    def __call__(
+        self,
+        predictions: torch.Tensor,
+        gold_labels: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ):
+        """
+        Parameters
+        ----------
+        predictions : ``torch.Tensor``, required.
+            A tensor of predictions of shape (batch_size, ..., num_classes).
+        gold_labels : ``torch.Tensor``, required.
+            A tensor of integer class label of shape (batch_size, ...). It must be the same
+            shape as the ``predictions`` tensor without the ``num_classes`` dimension.
+        mask: ``torch.Tensor``, optional (default = None).
+            A masking tensor the same size as ``gold_labels``.
+        """
+        predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
+
+        # Some sanity checks.
+        num_classes = predictions.size(-1)
+        if gold_labels.dim() != predictions.dim() - 1:
+            raise ConfigurationError(
+                "gold_labels must have dimension == predictions.size() - 1 but "
+                "found tensor of shape: {}".format(predictions.size())
+            )
+
+        predictions = predictions.view((-1, num_classes))
+        gold_labels = gold_labels.view(-1).long()
+
+        top_one_preds = predictions.max(-1)[1].unsqueeze(-1)
+
+        # NLI-specific filtering
+        top_one_preds = top_one_preds == 1
+        gold_labels = gold_labels == 1
+
+        # This is of shape (batch_size, ..., top_one_preds).
+        correct = top_one_preds.eq(gold_labels.unsqueeze(-1)).float()
+
+        if mask is not None:
+            correct *= mask.view(-1, 1).float()
+            self.total_count += mask.sum()
+        else:
+            self.total_count += gold_labels.numel()
+        self.correct_count += correct.sum()
+
+    def get_metric(self, reset: bool = False):
+        """
+        Returns
+        -------
+        The accumulated accuracy.
+        """
+        if self.total_count > 1e-12:
+            accuracy = float(self.correct_count) / float(self.total_count)
+        else:
+            accuracy = 0.0
+        if reset:
+            self.reset()
+        return accuracy
+
+    @overrides
+    def reset(self):
+        self.correct_count = 0.0
+        self.total_count = 0.0

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -1310,7 +1310,7 @@ class MultiNLITask(PairClassificationTask):
             + self.val_data_text[0]
             + self.val_data_text[1]
         )
-        log.info("\tFinished loading NLI data.")
+        log.info("\tFinished loading MNLI data.")
 
 
 @register_task("mnli-ho", rel_path="MNLI/")
@@ -1329,6 +1329,9 @@ class MultiNLIHypothesisOnlyTask(SingleClassificationTask):
         When genre is set to one of the ten MNLI genres, only examples matching that genre will be
         loaded in any split. That may result in some of the sections (train, dev mismatched, ...)
         being empty.
+
+        When two_class_evaluation is set, merge the contradiction and neutral labels, for both
+        predictions and gold labels, in the metric when evaluating on this task.
         """
         super(MultiNLIHypothesisOnlyTask, self).__init__(name, n_classes=3, **kw)
         self.path = path

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -1194,8 +1194,11 @@ class AdversarialNLITask(PairClassificationTask):
 
 
 @register_task("mnli", rel_path="MNLI/")
+# Alternate version with a modified evaluation metric. For use in transfer evaluations on
+# two-class test sets like RTE. Example config override:
+#   pretrain_tasks = mnli, target_tasks = \"mnli-two,rte\", rte += {use_classifier = mnli-two}
 @register_task("mnli-two", rel_path="MNLI/", two_class_evaluation=True)
-# second copy for different params
+# Second copy that can be assigned separate task-specific config options.
 @register_task("mnli-alt", rel_path="MNLI/")
 @register_task("mnli-fiction", rel_path="MNLI/", genre="fiction")
 @register_task("mnli-slate", rel_path="MNLI/", genre="slate")
@@ -1213,7 +1216,7 @@ class MultiNLITask(PairClassificationTask):
         being empty.
 
         When two_class_evaluation is set, merge the contradiction and neutral labels, for both
-        predictions and gold labels, before evaluating on this task.
+        predictions and gold labels, in the metric when evaluating on this task.
         """
         super(MultiNLITask, self).__init__(name, n_classes=3, **kw)
         self.path = path

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -38,6 +38,7 @@ from jiant.utils.data_loaders import (
 from jiant.utils.tokenizers import get_tokenizer
 from jiant.tasks.registry import register_task  # global task registry
 from jiant.metrics.winogender_metrics import GenderParity
+from jiant.metrics.nli_metrics import NLITwoClassAccuracy
 
 """Define the tasks and code for loading their data.
 
@@ -1193,6 +1194,7 @@ class AdversarialNLITask(PairClassificationTask):
 
 
 @register_task("mnli", rel_path="MNLI/")
+@register_task("mnli-two", rel_path="MNLI/", two_class_evaluation=True)
 # second copy for different params
 @register_task("mnli-alt", rel_path="MNLI/")
 @register_task("mnli-fiction", rel_path="MNLI/", genre="fiction")
@@ -1203,17 +1205,23 @@ class AdversarialNLITask(PairClassificationTask):
 class MultiNLITask(PairClassificationTask):
     """ Task class for Multi-Genre Natural Language Inference. """
 
-    def __init__(self, path, max_seq_len, name, genre=None, **kw):
+    def __init__(self, path, max_seq_len, name, genre=None, two_class_evaluation=False, **kw):
         """Set up the MNLI task object.
 
         When genre is set to one of the ten MNLI genres, only examples matching that genre will be
         loaded in any split. That may result in some of the sections (train, dev mismatched, ...)
         being empty.
+
+        When two_class_evaluation is set, merge the contradiction and neutral labels, for both
+        predictions and gold labels, before evaluating on this task.
         """
         super(MultiNLITask, self).__init__(name, n_classes=3, **kw)
         self.path = path
         self.max_seq_len = max_seq_len
         self.genre = genre
+        if two_class_evaluation:
+            self.scorer1 = NLITwoClassAccuracy()
+            self.scorers = [self.scorer1]
 
         self.train_data_text = None
         self.val_data_text = None
@@ -1299,10 +1307,11 @@ class MultiNLITask(PairClassificationTask):
             + self.val_data_text[0]
             + self.val_data_text[1]
         )
-        log.info("\tFinished loading MNLI data.")
+        log.info("\tFinished loading NLI data.")
 
 
 @register_task("mnli-ho", rel_path="MNLI/")
+@register_task("mnli-two-ho", rel_path="MNLI/", two_class_evaluation=True)
 @register_task("mnli-fiction-ho", rel_path="MNLI/", genre="fiction")
 @register_task("mnli-slate-ho", rel_path="MNLI/", genre="slate")
 @register_task("mnli-government-ho", rel_path="MNLI/", genre="government")
@@ -1311,7 +1320,7 @@ class MultiNLITask(PairClassificationTask):
 class MultiNLIHypothesisOnlyTask(SingleClassificationTask):
     """ Task class for MultiNLI hypothesis-only classification. """
 
-    def __init__(self, path, max_seq_len, name, genre=None, **kw):
+    def __init__(self, path, max_seq_len, name, genre=None, two_class_evaluation=False, **kw):
         """Set up the MNLI-HO task object.
 
         When genre is set to one of the ten MNLI genres, only examples matching that genre will be
@@ -1322,6 +1331,10 @@ class MultiNLIHypothesisOnlyTask(SingleClassificationTask):
         self.path = path
         self.max_seq_len = max_seq_len
         self.genre = genre
+
+        if two_class_evaluation:
+            self.scorer1 = NLITwoClassAccuracy()
+            self.scorers = [self.scorer1]
 
         self.train_data_text = None
         self.val_data_text = None

--- a/tests/test_nli_metric.py
+++ b/tests/test_nli_metric.py
@@ -1,0 +1,54 @@
+import unittest
+import torch
+
+from jiant.metrics.nli_metrics import NLITwoClassAccuracy
+
+
+class TestNLIMetric(unittest.TestCase):
+    def test_two_class_acc_w_two_class_data_and_model(self):
+        nli_scorer = NLITwoClassAccuracy()
+
+        # Note: predictions are of shape num_batches x batch_size x num_classes
+        predictions = torch.Tensor([[[0, 1], [0, 1]], [[1, 0], [1, 0]]])
+        true_labels = torch.Tensor([[1, 1], [0, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0
+
+        predictions = torch.Tensor([[[1, 0], [1, 0]], [[1, 0], [0, 1]]])
+        true_labels = torch.Tensor([[1, 1], [0, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0 / 4.0
+
+    def test_two_class_acc_w_two_class_data(self):
+        nli_scorer = NLITwoClassAccuracy()
+
+        # Note: predictions are of shape num_batches x batch_size x num_classes
+        predictions = torch.Tensor([[[0, 1, 0], [0, 1, 0]], [[0, 0, 1], [1, 0, 0]]])
+        true_labels = torch.Tensor([[1, 1], [0, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0
+
+        predictions = torch.Tensor([[[1, 0, 0], [1, 0, 0]], [[0, 0, 1], [0, 1, 0]]])
+        true_labels = torch.Tensor([[1, 1], [0, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0 / 4.0
+
+    def test_two_class_acc_w_two_class_model(self):
+        nli_scorer = NLITwoClassAccuracy()
+
+        # Note: predictions are of shape num_batches x batch_size x num_classes
+        predictions = torch.Tensor([[[0, 1], [0, 1]], [[1, 0], [1, 0]]])
+        true_labels = torch.Tensor([[1, 1], [2, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0
+
+        predictions = torch.Tensor([[[1, 0], [1, 0]], [[1, 0], [0, 1]]])
+        true_labels = torch.Tensor([[1, 1], [2, 0]])
+        nli_scorer(predictions, true_labels)
+        acc = nli_scorer.get_metric(reset=True)
+        assert acc == 1.0 / 4.0


### PR DESCRIPTION
This adds the option to train a model on the three-class MNLI dataset and evaluate it on comparable two-class datasets like RTE or HANS. It does this by overriding the usual accuracy metric with an NLI-specific accuracy metric that collapses 'neutral' and 'contradiction'.