### PR TITLE
Add gradient accumulation as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you use `jiant` in academic work, please cite it directly:
 
 ```
 @misc{wang2019jiant,
-    author = {Alex Wang and Ian F. Tenney and Yada Pruksachatkun and Katherin Yu and Jan Hula and Patrick Xia and Raghu Pappagari and Shuning Jin and R. Thomas McCoy and Roma Patel and Yinghui Huang and Jason Phang and Edouard Grave and Haokun Liu and Najoung Kim and Phu Mon Htut and Thibault F'{e}vry and Berlin Chen and Nikita Nangia and Anhad Mohananey and Katharina Kann and Shikha Bordia and Nicolas Patry and David Benton and Ellie Pavlick and Samuel R. Bowman},
+    author = {Alex Wang and Ian F. Tenney and Yada Pruksachatkun and Katherin Yu and Jan Hula and Patrick Xia and Raghu Pappagari and Shuning Jin and R. Thomas McCoy and Roma Patel and Yinghui Huang and Jason Phang and Edouard Grave and Haokun Liu and Najoung Kim and Phu Mon Htut and Thibault F\'evry and Berlin Chen and Nikita Nangia and Anhad Mohananey and Katharina Kann and Shikha Bordia and Nicolas Patry and David Benton and Ellie Pavlick and Samuel R. Bowman},
     title = {\texttt{jiant} 1.2: A software toolkit for research on general-purpose text understanding models},
     howpublished = {\url{http://jiant.info/}},
     year = {2019}

--- a/jiant/__main__.py
+++ b/jiant/__main__.py
@@ -150,9 +150,8 @@ def check_configurations(args, pretrain_tasks, target_tasks):
         log.warn("\tMixing training tasks with increasing and decreasing val metrics!")
 
     assert (
-        hasattr(args, "accumulation_steps") and args.accumulation_steps >= 1,
-        "accumulation_steps must be a positive int.",
-    )
+        hasattr(args, "accumulation_steps") and args.accumulation_steps >= 1
+    ), "accumulation_steps must be a positive int."
 
     if args.load_target_train_checkpoint != "none":
         assert_for_log(

--- a/jiant/__main__.py
+++ b/jiant/__main__.py
@@ -1,4 +1,4 @@
-"""Main flow for jiant. 
+"""Main flow for jiant.
 
 To debug this, run with -m ipdb:
 
@@ -148,6 +148,11 @@ def check_configurations(args, pretrain_tasks, target_tasks):
         [not t.val_metric_decreases for t in pretrain_tasks]
     ):
         log.warn("\tMixing training tasks with increasing and decreasing val metrics!")
+
+    assert_for_log(
+        hasattr(args, "accumulation_steps") and args.accumulation_steps >= 1,
+        "accumulation_steps must be a positive int",
+    )
 
     if args.load_target_train_checkpoint != "none":
         assert_for_log(

--- a/jiant/__main__.py
+++ b/jiant/__main__.py
@@ -149,9 +149,9 @@ def check_configurations(args, pretrain_tasks, target_tasks):
     ):
         log.warn("\tMixing training tasks with increasing and decreasing val metrics!")
 
-    assert_for_log(
+    assert (
         hasattr(args, "accumulation_steps") and args.accumulation_steps >= 1,
-        "accumulation_steps must be a positive int",
+        "accumulation_steps must be a positive int.",
     )
 
     if args.load_target_train_checkpoint != "none":

--- a/jiant/config/defaults.conf
+++ b/jiant/config/defaults.conf
@@ -161,12 +161,13 @@ val_data_limit = 5000  // Maximum number of examples to be used during mid-train
                        // by do_full_eval.
 val_interval = 1000  // Number of gradient steps to take between validation checks. Note that
                      // the stopping criteria are only checked at these intervals.
-accumulation_steps = 1 // The number of batches for which to accumulate gradients before taking
-                       // an optimizer step. If accumulation_steps = 2, then two batches/updates
-                       // are processed before taking one optimizer step. Training metrics (e.g.,
-                       // loss) are reported at step intervals, i.e., training with batch_size = n
-                       // and accumulation_steps = 2 approximates the training process with
-                       // double that batch size (batch_size = 2n) and accumulation_steps = 1.
+accumulation_steps = 1  // The number of batches for which to accumulate gradients before taking
+                        // an optimizer step. If accumulation_steps = 2, then two batches/updates
+                        // are processed before averaging the gradients. Training metrics (e.g.,
+                        // loss) are reported at step intervals, i.e., training with batch_size
+                        // = n and accumulation_steps = 2 simulates the training process with
+                        // batch_size = 2n and accumulation_steps = 1, with lower peak memory
+                        // usage and longer step time.
 max_vals = 1000  // Maximum number of validation checks. Will stop once this limit has been
                  // reached. This cannot be disabled, but if you plan to rely on max_epochs or
                  // min_lr instead for stopping training, simply set it to a very high number.

--- a/jiant/config/defaults.conf
+++ b/jiant/config/defaults.conf
@@ -161,8 +161,12 @@ val_data_limit = 5000  // Maximum number of examples to be used during mid-train
                        // by do_full_eval.
 val_interval = 1000  // Number of gradient steps to take between validation checks. Note that
                      // the stopping criteria are only checked at these intervals.
-accumulation_steps = 1 // the number of steps for which to accumulate the gradient before
-                       // an optimizer step. See https://medium.com/p/ec88c3e51255#e519 .
+accumulation_steps = 1 // The number of batches for which to accumulate gradients before taking
+                       // an optimizer step. If accumulation_steps = 2, then two batches/updates
+                       // are processed before taking one optimizer step. Training metrics (e.g.,
+                       // loss) are reported at step intervals, i.e., training with batch_size = n
+                       // and accumulation_steps = 2 approximates the training process with
+                       // double that batch size (batch_size = 2n) and accumulation_steps = 1.
 max_vals = 1000  // Maximum number of validation checks. Will stop once this limit has been
                  // reached. This cannot be disabled, but if you plan to rely on max_epochs or
                  // min_lr instead for stopping training, simply set it to a very high number.

--- a/jiant/config/defaults.conf
+++ b/jiant/config/defaults.conf
@@ -22,8 +22,8 @@
 
 // Misc. Logistics //
 
-cuda = auto  // GPU ID. Set to -1 for CPU, "auto" for all available GPUs on machine and 
-          // a comma-delimited list of GPU IDs for a subset of GPUs. 
+cuda = auto  // GPU ID. Set to -1 for CPU, "auto" for all available GPUs on machine and
+             // a comma-delimited list of GPU IDs for a subset of GPUs.
 random_seed = 1234  // Global random seed, used in both Python and PyTorch random number generators.
 track_batch_utilization = 0  // Track % of each batch that is padding tokens (for tasks with field
                              // 'input1').
@@ -161,7 +161,8 @@ val_data_limit = 5000  // Maximum number of examples to be used during mid-train
                        // by do_full_eval.
 val_interval = 1000  // Number of gradient steps to take between validation checks. Note that
                      // the stopping criteria are only checked at these intervals.
-
+accumulation_steps = 1 // the number of steps for which to accumulate the gradient before
+                       // an optimizer step. See https://medium.com/p/ec88c3e51255#e519 .
 max_vals = 1000  // Maximum number of validation checks. Will stop once this limit has been
                  // reached. This cannot be disabled, but if you plan to rely on max_epochs or
                  // min_lr instead for stopping training, simply set it to a very high number.

--- a/jiant/trainer.py
+++ b/jiant/trainer.py
@@ -332,8 +332,9 @@ class SamplingMultiTaskTrainer:
                 batch_size=batch_size,
                 biggest_batch_first=True,
             )
-            tr_generator = iterator(task.train_data, num_epochs=None)
             task_info["iterator"] = iterator
+            tr_generator = iterator(task.train_data, num_epochs=None)
+            task_info["tr_generator"] = tr_generator
 
             if phase == "pretrain":
                 # Warning: This won't be precise when training_data_fraction is set, since each
@@ -349,7 +350,6 @@ class SamplingMultiTaskTrainer:
                     task.n_train_examples / (batch_size * self._accumulation_steps)
                 )
 
-            task_info["tr_generator"] = tr_generator
             task_info["loss"] = 0.0
             task_info["total_batches_trained"] = 0
             task_info["n_batches_since_val"] = 0
@@ -587,12 +587,6 @@ class SamplingMultiTaskTrainer:
         offset = 0
         all_tr_metrics = {}
         log.info("Beginning training with stopping criteria based on metric: %s", stop_metric)
-        log.info(
-            "Effective batch size is %d (batch size %d * gradient accumulation steps %d)",
-            batch_size * self._accumulation_steps,
-            batch_size,
-            self._accumulation_steps,
-        )
         while not should_stop:
             self._model.train()
             task = samples[(n_step + offset) % validation_interval]  # randomly select a task

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -50,6 +50,7 @@ def build_trainer_params(args, cuda_device, task_names, phase="pretrain"):
         "val_interval": 1,
         "cuda": cuda_device,
         "keep_all_checkpoints": 1,
+        "accumulation_steps": 1,
     }
 
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -148,6 +148,8 @@ class TestCheckpointing(unittest.TestCase):
                     "tr_generator": iterator(self.wic.val_data, num_epochs=1),
                     "total_batches_trained": 400,
                     "n_batches_since_val": 0,
+                    "total_steps_trained": 400,
+                    "n_steps_since_val": 0,
                     "optimizer": optimizer,
                     "scheduler": scheduler,
                     "stopped": False,

--- a/tests/test_gradient_accumulation.py
+++ b/tests/test_gradient_accumulation.py
@@ -1,0 +1,65 @@
+import tempfile
+
+from pkg_resources import resource_filename
+import unittest
+from unittest import mock
+
+from jiant.__main__ import check_configurations
+from jiant.tasks import tasks
+from jiant.trainer import build_trainer
+from jiant.utils.config import params_from_file
+
+
+class TestGradientAccumulation(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.wic = tasks.WiCTask(self.temp_dir, 100, "wic", tokenizer_name="MosesTokenizer")
+
+    def test_steps_between_gradient_accumulations_must_be_defined(self):
+        self.args = params_from_file(resource_filename("jiant", "config/defaults.conf"))
+        del self.args.accumulation_steps
+        self.assertRaises(AssertionError, check_configurations, self.args, [], [])
+
+    def test_steps_between_gradient_accumulations_cannot_be_set_to_a_negative_number(self):
+        self.args = params_from_file(
+            resource_filename("jiant", "config/defaults.conf"), "accumulation_steps = -1"
+        )
+        self.assertRaises(AssertionError, check_configurations, self.args, [], [])
+
+    def test_by_default_steps_between_gradient_accumulations_is_set_to_1(self):
+        with mock.patch("jiant.models.MultiTaskModel") as MockModel:
+            self.args = params_from_file(resource_filename("jiant", "config/defaults.conf"))
+            self.args.cuda = -1
+            self.args.run_dir = self.temp_dir
+            self.args.exp_dir = self.temp_dir
+            model = MockModel()
+            _, train_params, _, _ = build_trainer(
+                self.args,
+                self.args.cuda,
+                ["wic"],
+                model,
+                self.args.run_dir,
+                self.wic.val_metric_decreases,
+                phase="pretrain",
+            )
+            self.assertEqual(train_params["accumulation_steps"], 1)
+
+    def test_steps_between_gradient_accumulations_can_be_overridden_and_set_greater_than_1(self):
+        with mock.patch("jiant.models.MultiTaskModel") as MockModel:
+            self.args = params_from_file(
+                resource_filename("jiant", "config/defaults.conf"), "accumulation_steps = 10"
+            )
+            self.args.cuda = -1
+            self.args.run_dir = self.temp_dir
+            self.args.exp_dir = self.temp_dir
+            model = MockModel()
+            _, train_params, _, _ = build_trainer(
+                self.args,
+                self.args.cuda,
+                ["wic"],
+                model,
+                self.args.run_dir,
+                self.wic.val_metric_decreases,
+                phase="pretrain",
+            )
+            self.assertEqual(train_params["accumulation_steps"], 10)


### PR DESCRIPTION
This PR adds gradient accumulation as a training option. Gradient accumulation allows us to increase the effective batch size (and use a wider range of GPUs for experiments).

We validated these changes on ReCoRD and BoolQ tasks where we confirmed that we can use gradient accumulation and smaller batch sizes to match the performance of larger batch sizes.