### PR TITLE
Specify version of black for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@
         - run:
             name: check style
             command: |
-              pip install --user black
+              pip install --user black==19.3b0
               black . --check --exclude "/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|jiant/modules/cove|venv)/"
         # Step 4: get data needed for demo.sh
         - run:


### PR DESCRIPTION
Currently, our pre-commit hook targets a specific version of the `black` Python style checker/fixer, but our CircleCI test tool automatically downloads the latest version. As of now, the latest version is substantially different from the version we target, so there can be cases where the automatic pre-commit style fix actually causes the code to fail the CircleCI style check. 

See, for example: https://circleci.com/workflow-run/502bba6a-1ffc-4845-83df-58094be11d4a?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification 

This change tells CircleCI to use the same fixed version we use locally for pre-commit. (This seems pretty clearly better than using the latest version in both places, as that could easily introduce confusing transient failures after new versions of `black` come out.)