### PR TITLE
Cleanup/readability changes in trainer.py

### DIFF
--- a/jiant/trainer.py
+++ b/jiant/trainer.py
@@ -669,6 +669,7 @@ class SamplingMultiTaskTrainer:
 
                 # Validate
                 log.info("Validating...")
+                # this call resets n_steps_since_val, n_batches_since_val, and loss_since_val = 0
                 all_val_metrics, should_save, new_best = self._validate(n_val, tasks, batch_size)
 
                 # Check stopping conditions


### PR DESCRIPTION
This PR cleans up a couple items in `jiant/trainer.py`:
1. a6fef61 changes the name of `task_info`'s "loss" field (which really tracks loss _since last val_ because it is reset as a side effect of calling `_validate`) to "loss_since_val".
2. There are a number of places in `SamplingMultiTaskTrainer` where a local var in a method is set to reference a field of the class. These extra variables / points of access can get confusing. 1cc7f6e and 37d6b32 make changes to access the member fields directly.
3. 7f72e96 makes changes to access dict values directly (instead of through extra local vars).