### PR TITLE
Use mean as reduction method for loss with DataParallel training

### DIFF
--- a/jiant/trainer.py
+++ b/jiant/trainer.py
@@ -580,7 +580,7 @@ class SamplingMultiTaskTrainer:
             for batch in itertools.islice(task_info["tr_generator"], self._accumulation_steps):
                 output_dict = self._forward(batch, task=task)
                 assert_for_log("loss" in output_dict, "Model must return a dict with 'loss' key")
-                loss = get_output_attribute(output_dict, "loss", self._cuda_device)
+                loss = get_output_attribute(output_dict, "loss", self._cuda_device, "mean")
                 # Losses are reduced as means. When aggregating loss for accumulation steps,
                 # losses are divided to calculate mean loss over batches within a step.
                 if self._accumulation_steps > 1:
@@ -843,7 +843,7 @@ class SamplingMultiTaskTrainer:
             batch_num += 1
             with torch.no_grad():
                 out = self._forward(batch, task=task)
-            loss = get_output_attribute(out, "loss", self._cuda_device)
+            loss = get_output_attribute(out, "loss", self._cuda_device, "mean")
 
             all_val_metrics["%s_loss" % task.name] += loss.data.cpu().numpy()
             n_examples += get_output_attribute(out, "n_exs", self._cuda_device)

--- a/jiant/utils/utils.py
+++ b/jiant/utils/utils.py
@@ -26,7 +26,7 @@ SOS_TOK, EOS_TOK = "<SOS>", "<EOS>"
 _MOSES_DETOKENIZER = MosesDetokenizer()
 
 
-def get_output_attribute(out, attribute_name, cuda_device):
+def get_output_attribute(out, attribute_name, cuda_device, reduction="sum"):
     """
     This function handles processing/reduction of output for both
     DataParallel or non-DataParallel situations.
@@ -36,12 +36,18 @@ def get_output_attribute(out, attribute_name, cuda_device):
 
     Parameters
     ---------------------
-    out: Dictionary, output of model during forward pass,
-    attribute_name: str,
-    cuda_device: list or int
+    :param out: Dictionary, output of model during forward pass,
+    :param attribute_name: str,
+    :param cuda_device: list or int
+    :param reduction: (string, optional) reduction to apply to the output. Default: 'sum'.
     """
     if isinstance(cuda_device, list):
-        return out[attribute_name].sum()
+        if reduction == "sum":
+            return out[attribute_name].sum()
+        elif reduction == "mean":
+            return out[attribute_name].sum() / float(len(out[attribute_name]))
+        else:
+            raise ValueError("invalid reduction type argument")
     else:
         return out[attribute_name]
 


### PR DESCRIPTION
This change makes loss metrics under different GPU configs more consistent by computing the average loss (instead of sum) across GPUs:
* 4b920c6 adds 'mean' as a reduction type option to `get_output_attribute` (the fn used to reduce scalars gathered in the output dict during DataParallel training). 
* 07a3b15 switches the `loss` calculation under DataParallel training to use 'mean' (instead of 'sum') as its reduction fn.