### PR TITLE
Minor change to maintain sorted order of tasks to reduce variation in logs

### DIFF
--- a/jiant/models.py
+++ b/jiant/models.py
@@ -1001,8 +1001,8 @@ class MultiTaskModel(nn.Module):
             # The assumption is that each space_token corresponds to multiple processed_tokens.
             # After we get the corresponding start/end space_token_indices, we can do " ".join
             #   to get the corresponding string that is definitely within the original input.
-            # One constraint here is that our predictions can only go up to a the granularity of space_tokens.
-            # This is not so bad because SQuAD-style scripts also remove punctuation.
+            # One constraint here is that our predictions can only go up to a the granularity of
+            # space_tokens. This is not so bad because SQuAD-style scripts also remove punctuation.
             pred_char_span_start = batch["space_processed_token_map"][i][pred_span_start_i][2]
             pred_char_span_end = batch["space_processed_token_map"][i][pred_span_end_i][2]
             pred_str_list.append(

--- a/jiant/models.py
+++ b/jiant/models.py
@@ -497,7 +497,7 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
     """
 
     # Attach task-specific params.
-    for task in tasks:
+    for task in sorted(set(tasks), key=lambda x: x.name):
         task_params = get_task_specific_params(args, task.name)
         log.info(
             "\tTask '%s' params: %s",
@@ -508,7 +508,7 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
         setattr(model, "%s_task_params" % task.name, task_params)
 
     # Actually construct modules.
-    for task in tasks:
+    for task in sorted(set(tasks), key=lambda x: x.name):
         # If the name of the task is different than the classifier it should use
         # then skip the module creation.
         if task.name != model._get_task_params(task.name).get("use_classifier", task.name):

--- a/jiant/models.py
+++ b/jiant/models.py
@@ -497,7 +497,7 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
     """
 
     # Attach task-specific params.
-    for task in set(tasks):
+    for task in tasks:
         task_params = get_task_specific_params(args, task.name)
         log.info(
             "\tTask '%s' params: %s",
@@ -508,7 +508,7 @@ def build_task_modules(args, tasks, model, d_sent, d_emb, embedder, vocab):
         setattr(model, "%s_task_params" % task.name, task_params)
 
     # Actually construct modules.
-    for task in set(tasks):
+    for task in tasks:
         # If the name of the task is different than the classifier it should use
         # then skip the module creation.
         if task.name != model._get_task_params(task.name).get("use_classifier", task.name):


### PR DESCRIPTION
Conversion of the [sorted tasks list](https://github.com/nyu-mll/jiant/blob/3ecea5584cd179588314451aaf515dd7922232ad/jiant/__main__.py#L516) to an [unordered set in build_task_modules](https://github.com/nyu-mll/jiant/blob/3ecea5584cd179588314451aaf515dd7922232ad/jiant/models.py#L500) is a source of variation in outputs on runs with the same configs (for example, see logs for "running demo.sh" on builds [1772](https://circleci.com/gh/nyu-mll/jiant/1772?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and [1776](https://circleci.com/gh/nyu-mll/jiant/1776?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)). This change maintains a sorted order for `tasks` making it easier to reproduce runs.