### PR TITLE
Pass config to tasks and drop task-specific logic from task builders

### DIFF
--- a/jiant/preprocess.py
+++ b/jiant/preprocess.py
@@ -55,6 +55,7 @@ from jiant.tasks import REGISTRY as TASKS_REGISTRY
 from jiant.tasks.seq2seq import Seq2SeqTask
 from jiant.tasks.tasks import SequenceGenerationTask, Task
 from jiant.utils import config, serialize, utils, options
+from jiant.utils.config import Params
 from jiant.utils.options import parse_task_list_arg
 
 # NOTE: these are not that same as AllenNLP SOS, EOS tokens
@@ -484,6 +485,7 @@ def _get_task(name: str, args: config.Params, data_path: str, scratch_path: str)
             max_seq_len=args.max_seq_len,
             name=name,
             tokenizer_name=args.tokenizer,
+            run_config=Params.clone(args),
             **task_kw,
         )
         task.load_data()
@@ -501,6 +503,7 @@ def get_task_without_loading_data(task_name, args):
         max_seq_len=args.max_seq_len,
         name=task_name,
         tokenizer_name=args.tokenizer,
+        run_config=Params.clone(args),
         **task_kw,
     )
     return task

--- a/jiant/preprocess.py
+++ b/jiant/preprocess.py
@@ -472,13 +472,6 @@ def _get_task(name: str, args: config.Params, data_path: str, scratch_path: str)
         log.info("\tLoaded existing task %s", name)
     else:
         log.info("\tCreating task %s from scratch.", name)
-        # These tasks take an additional kwarg.
-        if name == "nli-prob" or name == "nli-alt":
-            # TODO: remove special case, replace with something general
-            # to pass custom loader args to task.
-            task_kw["probe_path"] = args["nli-prob"].probe_path
-        if name in ALL_SEQ2SEQ_TASKS:
-            task_kw["max_targ_v_size"] = args.max_targ_word_v_size
         task_src_path = os.path.join(data_path, rel_path)
         task = task_cls(
             task_src_path,

--- a/jiant/tasks/nli_probing.py
+++ b/jiant/tasks/nli_probing.py
@@ -43,7 +43,7 @@ class NLITypeProbingTask(PairClassificationTask):
         super(NLITypeProbingTask, self).__init__(name, n_classes=3, **kw)
         self.path = path
         self.max_seq_len = max_seq_len
-        self.probe_path = run_config["nli-prob"].probe_path
+        self.probe_path = run_config.get("nli-prob", {}).get("probe_path")
 
         self.train_data_text = None
         self.val_data_text = None
@@ -73,11 +73,11 @@ class NLITypeProbingAltTask(NLITypeProbingTask):
 
     def __init__(self, path, max_seq_len, name, run_config, **kw):
         super(NLITypeProbingAltTask, self).__init__(
-            name=name, path=path, max_seq_len=max_seq_len, **kw
+            name=name, path=path, max_seq_len=max_seq_len, run_config=run_config, **kw
         )
         self.path = path
         self.max_seq_len = max_seq_len
-        self.probe_path = run_config["nli-prob"].probe_path
+        self.probe_path = run_config.get("nli-prob", {}).get("probe_path")
 
         self.train_data_text = None
         self.val_data_text = None

--- a/jiant/tasks/nli_probing.py
+++ b/jiant/tasks/nli_probing.py
@@ -39,11 +39,11 @@ class NPSTask(PairClassificationTask):
 class NLITypeProbingTask(PairClassificationTask):
     """ Task class for Probing Task (NLI-type)"""
 
-    def __init__(self, path, max_seq_len, name, probe_path="", **kw):
+    def __init__(self, path, max_seq_len, name, run_config, **kw):
         super(NLITypeProbingTask, self).__init__(name, n_classes=3, **kw)
         self.path = path
         self.max_seq_len = max_seq_len
-        self.probe_path = probe_path
+        self.probe_path = run_config["nli-prob"].probe_path
 
         self.train_data_text = None
         self.val_data_text = None
@@ -71,13 +71,13 @@ class NLITypeProbingTask(PairClassificationTask):
 class NLITypeProbingAltTask(NLITypeProbingTask):
     """ Task class for Alt Probing Task (NLI-type), NLITypeProbingTask with different indices"""
 
-    def __init__(self, path, max_seq_len, name, probe_path="", **kw):
+    def __init__(self, path, max_seq_len, name, run_config, **kw):
         super(NLITypeProbingAltTask, self).__init__(
             name=name, path=path, max_seq_len=max_seq_len, **kw
         )
         self.path = path
         self.max_seq_len = max_seq_len
-        self.probe_path = probe_path
+        self.probe_path = run_config["nli-prob"].probe_path
 
         self.train_data_text = None
         self.val_data_text = None

--- a/jiant/tasks/seq2seq.py
+++ b/jiant/tasks/seq2seq.py
@@ -21,7 +21,7 @@ from .tasks import (
 )
 
 
-@register_task("seg_wix", rel_path="seg/wix/", max_targ_v_size=200)
+@register_task("seg_wix", rel_path="seg/wix/")
 class Seq2SeqTask(SequenceGenerationTask):
     """Sequence-to-sequence Task"""
 

--- a/jiant/tasks/seq2seq.py
+++ b/jiant/tasks/seq2seq.py
@@ -25,7 +25,7 @@ from .tasks import (
 class Seq2SeqTask(SequenceGenerationTask):
     """Sequence-to-sequence Task"""
 
-    def __init__(self, path, max_seq_len, max_targ_v_size, name, **kw):
+    def __init__(self, path, max_seq_len, name, run_config, **kw):
         super().__init__(name, **kw)
         self.scorer2 = BooleanAccuracy()
         self.scorers.append(self.scorer2)
@@ -33,7 +33,7 @@ class Seq2SeqTask(SequenceGenerationTask):
         self.val_metric_decreases = False
         self.max_seq_len = max_seq_len
         self._label_namespace = self.name + "_tokens"
-        self.max_targ_v_size = max_targ_v_size
+        self.max_targ_v_size = run_config.max_targ_v_size
         self.target_indexer = {"words": SingleIdTokenIndexer(namespace=self._label_namespace)}
         self.files_by_split = {
             split: os.path.join(path, "%s.tsv" % split) for split in ["train", "val", "test"]

--- a/jiant/tasks/seq2seq.py
+++ b/jiant/tasks/seq2seq.py
@@ -33,7 +33,7 @@ class Seq2SeqTask(SequenceGenerationTask):
         self.val_metric_decreases = False
         self.max_seq_len = max_seq_len
         self._label_namespace = self.name + "_tokens"
-        self.max_targ_v_size = run_config.max_targ_v_size
+        self.max_targ_v_size = run_config.get("max_targ_v_size")
         self.target_indexer = {"words": SingleIdTokenIndexer(namespace=self._label_namespace)}
         self.files_by_split = {
             split: os.path.join(path, "%s.tsv" % split) for split in ["train", "val", "test"]

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -220,7 +220,7 @@ class Task(object):
         - optimizer
     """
 
-    def __init__(self, name, tokenizer_name):
+    def __init__(self, name, tokenizer_name, **kw):
         self.name = name
         self._tokenizer_name = tokenizer_name
         self.scorers = []
@@ -2726,7 +2726,7 @@ class WiCTask(PairClassificationTask):
 
         def _process_preserving_word(sent, word):
             """ Find out the index of the [first] instance of the word in the original sentence,
-            and project the span containing marked word to the span containing tokens created from 
+            and project the span containing marked word to the span containing tokens created from
             the marked word. """
             token_aligner, sent_tok = aligner_fn(sent)
             raw_start_idx = len(sent.split(word)[0].split(" ")) - 1

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,5 +1,6 @@
 import logging
 
+from jiant.utils.config import Params
 from jiant.tasks.registry import REGISTRY
 
 
@@ -17,5 +18,6 @@ def test_instantiate_all_tasks():
             max_seq_len=1,
             name="dummy_name",
             tokenizer_name="dummy_tokenizer_name",
+            run_config=Params(),
             **kw,
         )


### PR DESCRIPTION
Currently [the task building code in preprocessing.py](https://github.com/nyu-mll/jiant/blob/4666ed55572409e894921f6b082a899c3debed10/jiant/preprocess.py#L474-L480) contains logic to determine if the task being built is a special case that requires extracting task-specific parameters from the run config and, if so, it passes these params (among other keyword args) to the task's constructor as `**kwargs`. 

This PR would move responsibility for extracting task-specific params into the tasks themselves (by passing a copy of the run config directly to task constructors).

Advantages:
- makes it easier for task contributors to access config params from inside their tasks.
- addresses [todo in preprocessing.py: "remove special case, replace with something general"](https://github.com/nyu-mll/jiant/blob/master/jiant/preprocess.py#L476-L477).