### PR TITLE
Fix "wrong error description when both pretrain and target tasks are empty"

### DIFF
--- a/jiant/__main__.py
+++ b/jiant/__main__.py
@@ -181,14 +181,14 @@ def check_configurations(args, pretrain_tasks, target_tasks):
 
     if args.do_pretrain:
         assert_for_log(
-            args.pretrain_tasks != "none",
+            args.pretrain_tasks not in ("none", "", None),
             "Error: Must specify at least one pretraining task: [%s]" % args.pretrain_tasks,
         )
         steps_log.write("Training model on tasks: %s \n" % args.pretrain_tasks)
 
     if args.do_target_task_training:
         assert_for_log(
-            args.target_tasks != "none",
+            args.target_tasks not in ("none", "", None),
             "Error: Must specify at least one target task: [%s]" % args.target_tasks,
         )
         steps_log.write("Re-training model for individual target tasks \n")

--- a/jiant/preprocess.py
+++ b/jiant/preprocess.py
@@ -342,7 +342,7 @@ def build_tasks(
         setattr(task, "_classifier_name", task_classifier if task_classifier else task.name)
 
     tokenizer_names = {task.name: task.tokenizer_name for task in tasks}
-    assert len(set(tokenizer_names.values())) == 1, (
+    assert not len(set(tokenizer_names.values())) > 1, (
         f"Error: mixing tasks with different tokenizers!" " Tokenizations: {tokenizer_names:s}"
     )
 


### PR DESCRIPTION
Simple fix for https://github.com/nyu-mll/jiant/issues/1000: "wrong error description when both pretrain and target tasks are empty".

Previously, error read: `Error: mixing tasks with different tokenizers! Tokenizations`.

Error now reads: `Error: Must specify at least one pretraining task`, or `Error: Must specify at least one target task`. 

These changes continue to handle the case where task args are set to string "none", as demonstrated in [these configs](https://github.com/search?q=%22pretrain_tasks+%3D+none%22&type=Code).