### PR TITLE
Patch to fix micro average calculation under DataParallel

### DIFF
--- a/jiant/trainer.py
+++ b/jiant/trainer.py
@@ -865,7 +865,7 @@ class SamplingMultiTaskTrainer:
                                 log.info("\tInput:\t%s", input_string)
                                 log.info("\tGold:\t%s", gold_string)
                             log.info("\tOutput:\t%s", output_string)
-            n_examples += get_output_attribute(out, "n_exs", self._cuda_device)
+
             # log
             if time.time() - task_info["last_log"] > self._log_interval:
                 task_metrics = task.get_metrics()


### PR DESCRIPTION
This PR patches issue #1011, "Micro average logged as 0.000 for some tasks":

1. 84729e8 removes an instance of double counting of `n_exs` in validation metric calc
2. 23dad18 extracts n_exs differently w/ single- and multi-GPUs (single -> int, multi -> tensor)

These changes were validated on the `commitbank` task in single- and multi-GPU modes.
These changes were not validated across the whole set of tasks/benchmarks used in [#992](https://github.com/nyu-mll/jiant/pull/992#issuecomment-588256306).