### PR TITLE
Revert "Address max sequence length issue (#1002)"

### DIFF
--- a/jiant/huggingface_transformers_interface/modules.py
+++ b/jiant/huggingface_transformers_interface/modules.py
@@ -189,7 +189,7 @@ class HuggingfaceTransformersEmbedderModule(nn.Module):
         return seg_ids
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         """
         A function that appliese the appropriate EOS/SOS/SEP/CLS tokens to token sequence or
         token sequence pair for most tasks.
@@ -274,7 +274,7 @@ class BertEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # BERT-style boundary token padding on string token sequences
         if s2:
             s = ["[CLS]"] + s1 + ["[SEP]"] + s2 + ["[SEP]"]
@@ -331,7 +331,7 @@ class RobertaEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # RoBERTa-style boundary token padding on string token sequences
         if s2:
             s = ["<s>"] + s1 + ["</s>", "</s>"] + s2 + ["</s>"]
@@ -385,7 +385,7 @@ class AlbertEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # ALBERT-style boundary token padding on string token sequences
         if s2:
             s = ["[CLS]"] + s1 + ["[SEP]"] + s2 + ["[SEP]"]
@@ -448,7 +448,7 @@ class XLNetEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self._SEG_ID_SEP = 3
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # XLNet-style boundary token marking on string token sequences
         if s2:
             s = s1 + ["<sep>"] + s2 + ["<sep>", "<cls>"]
@@ -506,7 +506,7 @@ class OpenAIGPTEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # OpenAI-GPT-style boundary token marking on string token sequences
         if s2:
             s = ["<start>"] + s1 + ["<delim>"] + s2 + ["<extract>"]
@@ -568,7 +568,7 @@ class GPT2EmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # GPT-2-style boundary token marking on string token sequences
         if s2:
             s = ["<start>"] + s1 + ["<delim>"] + s2 + ["<extract>"]
@@ -630,7 +630,7 @@ class TransfoXLEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # TransformerXL-style boundary token marking on string token sequences
         if s2:
             s = ["<start>"] + s1 + ["<delim>"] + s2 + ["<extract>"]
@@ -697,7 +697,7 @@ class XLMEmbedderModule(HuggingfaceTransformersEmbedderModule):
         self.parameter_setup(args)
 
     @staticmethod
-    def apply_boundary_tokens(s1, *, s2=None, get_offset=False):
+    def apply_boundary_tokens(s1, s2=None, get_offset=False):
         # XLM-style boundary token marking on string token sequences
         if s2:
             s = ["</s>"] + s1 + ["</s>"] + s2 + ["</s>"]

--- a/jiant/preprocess.py
+++ b/jiant/preprocess.py
@@ -740,202 +740,53 @@ class ModelPreprocessingInterface(object):
 
     """
 
-    @staticmethod
-    def _apply_boundary_tokens(apply_boundary_tokens, max_tokens):
-        """
-        Takes a function that applies boundary tokens and modifies it to respect a max_seq_len arg.
-
-        Parameters
-        ----------
-        apply_boundary_tokens : function
-            Takes a function that adds boundary tokens and implements the common boundary token
-            adding function interface demonstated in HuggingfaceTransformersEmbedderModule.
-        max_tokens : int
-            The maximum number of tokens to allow in the output sequence.
-
-        Returns
-        -------
-        apply_boundary_tokens_with_trunc_strategy : function
-            Function w/ the common boundary token adding interface demonstrated in
-            HuggingfaceTransformersEmbedderModule, but also implementing a truncation strategy.
-        """
-
-        def _apply_boundary_tokens_with_trunc_strategy(
-            *args, trunc_strategy=None, trunc_side=None, **kwargs
-        ):
-            """
-            Calls the apply_boundary_tokens function provided in the parent function and, if the
-            output exceeds the max number of tokens, applies a truncation strategy to the inputs,
-            then re-applies the apply_boundary_tokens function on the truncated inputs and returns
-            the result.
-
-            Parameters
-            ----------
-            args : tuple
-                see args docs for apply_boundary_tokens and apply_lm_boundary_tokens in
-                huggingface_transformers_interface.modules
-            trunc_strategy : str
-                Which strings to truncate. Options:
-                    `trunc_s1`: select s1 for truncation.
-                    `trunc_s2`: select s2 for truncation.
-                    `trunc_both`: truncate s1 and s2 equally.
-            trunc_side : str
-                Options are `right` or `left`. Indicates which side of the sequence to remove from.
-                e.g., if `left`, then the first element to be removed from ["A", "B", "C"] is "A".
-            kwargs : dict
-                see args docs for apply_boundary_tokens and apply_lm_boundary_tokens in
-                huggingface_transformers_interface.modules
-
-            Returns
-            -------
-            seq_w_boundry_tokens : List[str]
-                List of tokens returned by applying the specified apply_boundary_tokens function
-                to the inputs and using the specified truncation strategy.
-
-            Raises
-            ------
-            ValueError
-                If sequence requires truncation but trunc_strategy or trunc_side are unspecified
-                or invalid.
-
-            """
-            seq_w_boundry_tokens = apply_boundary_tokens(*args, **kwargs)
-            # if after calling the apply_boundary_tokens function the number of tokens is greater
-            # than the model's max, a truncation strategy can reduce the number of tokens:
-            num_excess_tokens = len(seq_w_boundry_tokens) - max_tokens
-            if num_excess_tokens > 0:
-                if not (trunc_strategy and trunc_side):
-                    raise ValueError(
-                        "Input(s) length will exceed model capacity or max_seq_len. "
-                        + "Adjust settings as necessary, or, to automatically truncate "
-                        + "inputs in `apply_boundary_tokens`, call `apply_boundary_tokens` "
-                        + "with `trunc_strategy` and `trunc_side` keyword args."
-                    )
-                if trunc_strategy == "trunc_s2":
-                    s2 = kwargs["s2"]
-                    if trunc_side == "right":
-                        s2_truncated = s2[:-num_excess_tokens]
-                    elif trunc_side == "left":
-                        s2_truncated = s2[num_excess_tokens:]
-                    log.info(
-                        "Before truncation s2 length = "
-                        + str(len(s2))
-                        + ", after truncation s2 length = "
-                        + str(len(s2_truncated))
-                    )
-                    assert len(s2_truncated) > 0, "After truncation, s2 length would be 0."
-                    args = list(args)
-                    kwargs["s2"] = s2_truncated
-                    return apply_boundary_tokens(*args, **kwargs)
-                elif trunc_strategy == "trunc_both":
-                    s1 = args[0]
-                    s2 = kwargs["s2"]
-                    if trunc_side == "right":
-                        s1_truncated = s1[: -num_excess_tokens // 2]
-                        s2_truncated = s2[: -num_excess_tokens // 2]
-                    elif trunc_side == "left":
-                        s1_truncated = s1[num_excess_tokens // 2 :]
-                        s2_truncated = s2[num_excess_tokens // 2 :]
-                    log.info(
-                        "Before truncation s1 length = "
-                        + str(len(s1))
-                        + " and s2 length = "
-                        + str(len(s2))
-                        + ". After truncation s1 length = "
-                        + str(len(s1_truncated))
-                        + " and s2 length = "
-                        + str(len(s2_truncated))
-                    )
-                    assert len(s1_truncated) > 0, "After truncation, s1 length would be 0."
-                    assert len(s2_truncated) > 0, "After truncation, s2 length would be 0."
-                    args = list(args)
-                    args[0] = s1_truncated
-                    kwargs["s2"] = s2_truncated
-                    return apply_boundary_tokens(*args, **kwargs)
-                elif trunc_strategy == "trunc_s1":
-                    s1 = args[0]
-                    if trunc_side == "right":
-                        s1_truncated = s1[:-num_excess_tokens]
-                    elif trunc_side == "left":
-                        s1_truncated = s1[num_excess_tokens:]
-                    log.info(
-                        "Before truncation s1 length = "
-                        + str(len(s1))
-                        + ", after truncation s1 length = "
-                        + str(len(s1_truncated))
-                    )
-                    assert len(s1_truncated) > 0, "After truncation, s1 length would be 0."
-                    args = list(args)
-                    args[0] = s1_truncated
-                    return apply_boundary_tokens(*args, **kwargs)
-                else:
-                    raise ValueError(trunc_strategy + " is not a valid truncation strategy.")
-            else:
-                return seq_w_boundry_tokens
-
-        return _apply_boundary_tokens_with_trunc_strategy
-
     def __init__(self, args):
         boundary_token_fn = None
         lm_boundary_token_fn = None
-        max_pos: int = None
 
         if args.input_module.startswith("bert-"):
             from jiant.huggingface_transformers_interface.modules import BertEmbedderModule
 
             boundary_token_fn = BertEmbedderModule.apply_boundary_tokens
-            max_pos = BertTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("roberta-"):
             from jiant.huggingface_transformers_interface.modules import RobertaEmbedderModule
 
             boundary_token_fn = RobertaEmbedderModule.apply_boundary_tokens
-            max_pos = RobertaTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("albert-"):
             from jiant.huggingface_transformers_interface.modules import AlbertEmbedderModule
 
             boundary_token_fn = AlbertEmbedderModule.apply_boundary_tokens
-            max_pos = AlbertTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("xlnet-"):
             from jiant.huggingface_transformers_interface.modules import XLNetEmbedderModule
 
             boundary_token_fn = XLNetEmbedderModule.apply_boundary_tokens
-            max_pos = XLNetTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("openai-gpt"):
             from jiant.huggingface_transformers_interface.modules import OpenAIGPTEmbedderModule
 
             boundary_token_fn = OpenAIGPTEmbedderModule.apply_boundary_tokens
             lm_boundary_token_fn = OpenAIGPTEmbedderModule.apply_lm_boundary_tokens
-            max_pos = OpenAIGPTTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("gpt2"):
             from jiant.huggingface_transformers_interface.modules import GPT2EmbedderModule
 
             boundary_token_fn = GPT2EmbedderModule.apply_boundary_tokens
             lm_boundary_token_fn = GPT2EmbedderModule.apply_lm_boundary_tokens
-            max_pos = GPT2Tokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("transfo-xl-"):
             from jiant.huggingface_transformers_interface.modules import TransfoXLEmbedderModule
 
             boundary_token_fn = TransfoXLEmbedderModule.apply_boundary_tokens
             lm_boundary_token_fn = TransfoXLEmbedderModule.apply_lm_boundary_tokens
-            max_pos = TransfoXLTokenizer.max_model_input_sizes.get(args.input_module, None)
         elif args.input_module.startswith("xlm-"):
             from jiant.huggingface_transformers_interface.modules import XLMEmbedderModule
 
             boundary_token_fn = XLMEmbedderModule.apply_boundary_tokens
-            max_pos = XLMTokenizer.max_model_input_sizes.get(args.input_module, None)
         else:
             boundary_token_fn = utils.apply_standard_boundary_tokens
 
-        self.max_tokens = min(x for x in [max_pos, args.max_seq_len] if x is not None)
-
-        self.boundary_token_fn = self._apply_boundary_tokens(boundary_token_fn, self.max_tokens)
-
+        self.boundary_token_fn = boundary_token_fn
         if lm_boundary_token_fn is not None:
-            self.lm_boundary_token_fn = self._apply_boundary_tokens(
-                lm_boundary_token_fn, args.max_seq_len
-            )
+            self.lm_boundary_token_fn = lm_boundary_token_fn
         else:
-            self.lm_boundary_token_fn = self.boundary_token_fn
+            self.lm_boundary_token_fn = boundary_token_fn
 
         from jiant.models import input_module_uses_pair_embedding, input_module_uses_mirrored_pair
 

--- a/jiant/tasks/edge_probing.py
+++ b/jiant/tasks/edge_probing.py
@@ -182,7 +182,7 @@ class EdgeProbingTask(Task):
         """Convert a single record to an AllenNLP Instance."""
         tokens = record["text"].split()  # already space-tokenized by Moses
         tokens = model_preprocessing_interface.boundary_token_fn(
-            tokens, trunc_strategy="trunc_s1", trunc_side="right"
+            tokens
         )  # apply model-appropriate variants of [cls] and [sep].
         text_field = sentence_to_text_field(tokens, indexers)
 

--- a/jiant/tasks/qa.py
+++ b/jiant/tasks/qa.py
@@ -120,16 +120,11 @@ class MultiRCTask(Task):
             d["ans_idx"] = MetadataField(ans_idx)
             d["idx"] = MetadataField(ans_idx)  # required by evaluate()
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
-                inp = model_preprocessing_interface.boundary_token_fn(
-                    para, s2=question + answer, trunc_strategy="trunc_s1", trunc_side="right"
-                )
+                inp = model_preprocessing_interface.boundary_token_fn(para, question + answer)
                 d["psg_qst_ans"] = sentence_to_text_field(inp, indexers)
             else:
                 d["psg"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        passage, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(passage), indexers
                 )
                 d["qst"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(question), indexers
@@ -313,16 +308,11 @@ class ReCoRDTask(Task):
             d["ans_idx"] = MetadataField(ans_idx)
             d["idx"] = MetadataField(ans_idx)  # required by evaluate()
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
-                inp = model_preprocessing_interface.boundary_token_fn(
-                    psg, s2=qst, trunc_strategy="trunc_s1", trunc_side="right"
-                )
+                inp = model_preprocessing_interface.boundary_token_fn(psg, qst)
                 d["psg_qst_ans"] = sentence_to_text_field(inp, indexers)
             else:
                 d["psg"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        psg, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(psg), indexers
                 )
                 d["qst"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(qst), indexers
@@ -468,19 +458,12 @@ class QASRLTask(SpanPredictionTask):
 
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 inp, start_offset, _ = model_preprocessing_interface.boundary_token_fn(
-                    example["passage"],
-                    s2=example["question"],
-                    trunc_strategy="trunc_s1",
-                    trunc_side="right",
-                    get_offset=True,
+                    example["passage"], example["question"], get_offset=True
                 )
                 d["inputs"] = sentence_to_text_field(inp, indexers)
             else:
                 d["passage"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        example["passage"], trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(example["passage"]), indexers
                 )
                 d["question"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(example["question"]), indexers
@@ -631,19 +614,12 @@ class QAMRTask(SpanPredictionTask):
 
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 inp, start_offset, _ = model_preprocessing_interface.boundary_token_fn(
-                    example["passage"],
-                    s2=example["question"],
-                    trunc_strategy="trunc_s1",
-                    trunc_side="right",
-                    get_offset=True,
+                    example["passage"], example["question"], get_offset=True
                 )
                 d["inputs"] = sentence_to_text_field(inp, indexers)
             else:
                 d["passage"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        example["passage"], trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(example["passage"]), indexers
                 )
                 d["question"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(example["question"]), indexers
@@ -909,16 +885,11 @@ class CommonsenseQATask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(question))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(question), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, s2=choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(question, choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )
@@ -1012,16 +983,11 @@ class CosmosQATask(MultipleChoiceTask):
             d["context_str"] = MetadataField(" ".join(context))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["context"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(context), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, s2=choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(context, choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )

--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -108,25 +108,18 @@ def process_single_pair_task_split(
         d = {}
         d["sent1_str"] = MetadataField(" ".join(input1))
         if model_preprocessing_interface.model_flags["uses_pair_embedding"] and is_pair:
-            inp = model_preprocessing_interface.boundary_token_fn(
-                input1, s2=input2, trunc_strategy="trunc_s1", trunc_side="right"
-            )
+            inp = model_preprocessing_interface.boundary_token_fn(input1, input2)
             d["inputs"] = sentence_to_text_field(inp, indexers)
             d["sent2_str"] = MetadataField(" ".join(input2))
             if (
                 model_preprocessing_interface.model_flags["uses_mirrored_pair"]
                 and is_symmetrical_pair
             ):
-                inp_m = model_preprocessing_interface.boundary_token_fn(
-                    input1, s2=input2, trunc_strategy="trunc_s1", trunc_side="right"
-                )
+                inp_m = model_preprocessing_interface.boundary_token_fn(input1, input2)
                 d["inputs_m"] = sentence_to_text_field(inp_m, indexers)
         else:
             d["input1"] = sentence_to_text_field(
-                model_preprocessing_interface.boundary_token_fn(
-                    input1, trunc_strategy="trunc_s1", trunc_side="right"
-                ),
-                indexers,
+                model_preprocessing_interface.boundary_token_fn(input1), indexers
             )
             if input2:
                 d["input2"] = sentence_to_text_field(
@@ -795,10 +788,7 @@ class CoLAAnalysisTask(SingleClassificationTask):
             """ from multiple types in one column create multiple fields """
             d = {}
             d["input1"] = sentence_to_text_field(
-                model_preprocessing_interface.boundary_token_fn(
-                    input1, trunc_strategy="trunc_s1", trunc_side="right"
-                ),
-                indexers,
+                model_preprocessing_interface.boundary_token_fn(input1), indexers
             )
             d["sent1_str"] = MetadataField(" ".join(input1))
             d["labels"] = LabelField(labels, label_namespace="labels", skip_indexing=True)
@@ -1631,16 +1621,11 @@ class GLUEDiagnosticTask(PairClassificationTask):
             """ from multiple types in one column create multiple fields """
             d = {}
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
-                inp = model_preprocessing_interface.boundary_token_fn(
-                    input1, s2=input2, trunc_strategy="trunc_s1", trunc_side="right"
-                )
+                inp = model_preprocessing_interface.boundary_token_fn(input1, input2)
                 d["inputs"] = sentence_to_text_field(inp, indexers)
             else:
                 d["input1"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        input1, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(input1), indexers
                 )
                 d["input2"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(input2), indexers
@@ -1844,17 +1829,12 @@ class WinogenderTask(GLUEDiagnosticTask):
             d = {}
             d["sent1_str"] = MetadataField(" ".join(input1))
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
-                inp = model_preprocessing_interface.boundary_token_fn(
-                    input1, s2=input2, trunc_strategy="trunc_s1", trunc_side="right"
-                )
+                inp = model_preprocessing_interface.boundary_token_fn(input1, input2)
                 d["inputs"] = sentence_to_text_field(inp, indexers)
                 d["sent2_str"] = MetadataField(" ".join(input2))
             else:
                 d["input1"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        input1, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(input1), indexers
                 )
                 if input2:
                     d["input2"] = sentence_to_text_field(
@@ -2211,10 +2191,7 @@ class Wiki103Classification(PairClassificationTask):
         def _make_instance(input1, input2, labels):
             d = {}
             d["input1"] = sentence_to_text_field(
-                model_preprocessing_interface.boundary_token_fn(
-                    input1, trunc_strategy="trunc_s1", trunc_side="right"
-                ),
-                indexers,
+                model_preprocessing_interface.boundary_token_fn(input1), indexers
             )
             d["input2"] = sentence_to_text_field(
                 model_preprocessing_interface.boundary_token_fn(input2), indexers
@@ -2314,15 +2291,12 @@ class DisSentTask(PairClassificationTask):
             d = {}
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 inp = model_preprocessing_interface.boundary_token_fn(
-                    input1, s2=input2, trunc_strategy="trunc_s1", trunc_side="right"
+                    input1, input2
                 )  # drop leading [CLS] token
                 d["inputs"] = sentence_to_text_field(inp, indexers)
             else:
                 d["input1"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        input1, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(input1), indexers
                 )
                 d["input2"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(input2), indexers
@@ -2461,10 +2435,7 @@ class CCGTaggingTask(TaggingTask):
         def _make_instance(input1, input2, target, mask):
             d = {}
             d["inputs"] = sentence_to_text_field(
-                model_preprocessing_interface.boundary_token_fn(
-                    input1, trunc_strategy="trunc_s1", trunc_side="right"
-                ),
-                indexers,
+                model_preprocessing_interface.boundary_token_fn(input1), indexers
             )
             d["sent1_str"] = MetadataField(" ".join(input1))
             d["targs"] = sentence_to_text_field(target, self.target_indexer)
@@ -2646,9 +2617,7 @@ class SpanClassificationTask(Task):
     def make_instance(self, record, idx, indexers, model_preprocessing_interface) -> Type[Instance]:
         """Convert a single record to an AllenNLP Instance."""
         tokens = record["text"].split()
-        tokens, offset = model_preprocessing_interface.boundary_token_fn(
-            tokens, trunc_strategy="trunc_s1", trunc_side="right", get_offset=True
-        )
+        tokens, offset = model_preprocessing_interface.boundary_token_fn(tokens, get_offset=True)
         text_field = sentence_to_text_field(tokens, indexers)
 
         example = {}
@@ -2866,16 +2835,12 @@ class WiCTask(PairClassificationTask):
             d["sent2_str"] = MetadataField(" ".join(input2))
             if model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 inp, offset1, offset2 = model_preprocessing_interface.boundary_token_fn(
-                    input1,
-                    s2=input2,
-                    trunc_strategy="trunc_s1",
-                    trunc_side="right",
-                    get_offset=True,
+                    input1, input2, get_offset=True
                 )
                 d["inputs"] = sentence_to_text_field(inp[: self.max_seq_len], indexers)
             else:
                 inp1, offset1 = model_preprocessing_interface.boundary_token_fn(
-                    input1, trunc_strategy="trunc_s1", trunc_side="right", get_offset=True
+                    input1, get_offset=True
                 )
                 inp2, offset2 = model_preprocessing_interface.boundary_token_fn(
                     input2, get_offset=True
@@ -3003,16 +2968,11 @@ class SocialIQATask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(context))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(context), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, s2=question + choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(context, question + choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )
@@ -3171,16 +3131,11 @@ class COPATask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(context))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(context), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, s2=question + choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(context, question + choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )
@@ -3262,16 +3217,11 @@ class SWAGTask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(question))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(question), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, s2=choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(question, choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )
@@ -3358,16 +3308,11 @@ class HellaSwagTask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(question))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(question), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        question, s2=choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(question, choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )
@@ -3486,17 +3431,14 @@ class BooleanQuestionTask(PairClassificationTask):
             new_d["passage_str"] = MetadataField(" ".join(d["passage"]))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 new_d["input1"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        d["passage"], trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(d["passage"]), indexers
                 )
                 new_d["input2"] = sentence_to_text_field(
                     model_preprocessing_interface.boundary_token_fn(d["question"]), indexers
                 )
             else:  # BERT/XLNet
                 psg_qst = model_preprocessing_interface.boundary_token_fn(
-                    d["passage"], s2=d["question"], trunc_strategy="trunc_s1", trunc_side="right"
+                    d["passage"], d["question"]
                 )
                 new_d["inputs"] = sentence_to_text_field(psg_qst, indexers)
             new_d["labels"] = LabelField(d["label"], label_namespace="labels", skip_indexing=True)
@@ -3619,7 +3561,7 @@ class AlphaNLITask(MultipleChoiceTask):
             else:
                 for hyp_idx, hyp in enumerate([hyp1, hyp2]):
                     inp = (
-                        model_preprocessing_interface.boundary_token_fn(obs1 + hyp, s2=obs2)
+                        model_preprocessing_interface.boundary_token_fn(obs1 + hyp, obs2)
                         if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                         else model_preprocessing_interface.boundary_token_fn(hyp)
                     )
@@ -3767,16 +3709,11 @@ class WinograndeTask(MultipleChoiceTask):
             d["question_str"] = MetadataField(" ".join(context))
             if not model_preprocessing_interface.model_flags["uses_pair_embedding"]:
                 d["question"] = sentence_to_text_field(
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, trunc_strategy="trunc_s1", trunc_side="right"
-                    ),
-                    indexers,
+                    model_preprocessing_interface.boundary_token_fn(context), indexers
                 )
             for choice_idx, choice in enumerate(choices):
                 inp = (
-                    model_preprocessing_interface.boundary_token_fn(
-                        context, s2=choice, trunc_strategy="trunc_s1", trunc_side="right"
-                    )
+                    model_preprocessing_interface.boundary_token_fn(context, choice)
                     if model_preprocessing_interface.model_flags["uses_pair_embedding"]
                     else model_preprocessing_interface.boundary_token_fn(choice)
                 )

--- a/jiant/utils/utils.py
+++ b/jiant/utils/utils.py
@@ -98,7 +98,7 @@ def select_pool_type(args):
     return pool_type
 
 
-def apply_standard_boundary_tokens(s1, *, s2=None):
+def apply_standard_boundary_tokens(s1, s2=None):
     """Apply <SOS> and <EOS> to sequences of string-valued tokens.
     Corresponds to more complex functions used with models like XLNet and BERT.
     """

--- a/tests/test_huggingface_transformers_interface.py
+++ b/tests/test_huggingface_transformers_interface.py
@@ -23,7 +23,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             BertEmbedderModule.apply_boundary_tokens(s1), ["[CLS]", "A", "B", "C", "[SEP]"]
         )
         self.assertListEqual(
-            BertEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            BertEmbedderModule.apply_boundary_tokens(s1, s2),
             ["[CLS]", "A", "B", "C", "[SEP]", "D", "E", "[SEP]"],
         )
 
@@ -34,7 +34,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             RobertaEmbedderModule.apply_boundary_tokens(s1), ["<s>", "A", "B", "C", "</s>"]
         )
         self.assertListEqual(
-            RobertaEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            RobertaEmbedderModule.apply_boundary_tokens(s1, s2),
             ["<s>", "A", "B", "C", "</s>", "</s>", "D", "E", "</s>"],
         )
 
@@ -45,7 +45,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             AlbertEmbedderModule.apply_boundary_tokens(s1), ["[CLS]", "A", "B", "C", "[SEP]"]
         )
         self.assertListEqual(
-            AlbertEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            AlbertEmbedderModule.apply_boundary_tokens(s1, s2),
             ["[CLS]", "A", "B", "C", "[SEP]", "D", "E", "[SEP]"],
         )
 
@@ -56,7 +56,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             XLNetEmbedderModule.apply_boundary_tokens(s1), ["A", "B", "C", "<sep>", "<cls>"]
         )
         self.assertListEqual(
-            XLNetEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            XLNetEmbedderModule.apply_boundary_tokens(s1, s2),
             ["A", "B", "C", "<sep>", "D", "E", "<sep>", "<cls>"],
         )
 
@@ -68,7 +68,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             ["<start>", "A", "B", "C", "<extract>"],
         )
         self.assertListEqual(
-            OpenAIGPTEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            OpenAIGPTEmbedderModule.apply_boundary_tokens(s1, s2),
             ["<start>", "A", "B", "C", "<delim>", "D", "E", "<extract>"],
         )
 
@@ -79,7 +79,7 @@ class TestHuggingfaceTransformersInterface(unittest.TestCase):
             XLMEmbedderModule.apply_boundary_tokens(s1), ["</s>", "A", "B", "C", "</s>"]
         )
         self.assertListEqual(
-            XLMEmbedderModule.apply_boundary_tokens(s1, s2=s2),
+            XLMEmbedderModule.apply_boundary_tokens(s1, s2),
             ["</s>", "A", "B", "C", "</s>", "D", "E", "</s>"],
         )
 


### PR DESCRIPTION
Final pre-release validations found inconsistencies in whether `s1` or `s2` contained the candidate for truncation. This PR reverts PR nyu-mll/jiant#1006, and issue #1002 remains open to track work on a fix.