### PR TITLE
Address issue #1018: QAMR and QASRL throw `AttributeError`

### DIFF
--- a/jiant/tasks/qa.py
+++ b/jiant/tasks/qa.py
@@ -540,7 +540,7 @@ class QASRLTask(SpanPredictionTask):
         )
 
     def get_split_text(self, split: str):
-        return getattr(self, "%s_data" % split)
+        return getattr(self, "%s_data_text" % split)
 
     @classmethod
     def preprocess_qasrl_datum(cls, datum):
@@ -641,7 +641,7 @@ class QAMRTask(SpanPredictionTask):
         return instances
 
     def get_split_text(self, split: str):
-        return getattr(self, "%s_data" % split)
+        return getattr(self, "%s_data_text" % split)
 
     @classmethod
     def load_tsv_dataset(cls, path, wiki_dict):


### PR DESCRIPTION
Issue #1018 points out that QAMR and QASRL throw `AttributeError` on access to Task data fields (these fields were modified in PR #1004). This PR fixes `get_split_text`'s access to these fields.

The changes in this PR were validated by starting training w/ QAMR and QASRL tasks (w/o failure).

@HaokunLiu — for visibility as author of issue #1018.