### PR TITLE
WIP: Extend edge probing fix to run in multi-GPU mode

### DIFF
--- a/jiant/models.py
+++ b/jiant/models.py
@@ -571,10 +571,6 @@ def build_task_specific_modules(task, model, d_sent, d_emb, vocab, embedder, arg
         )
         setattr(model, "%s_mdl" % task.name, module)
     elif isinstance(task, EdgeProbingTask):
-        assert_for_log(
-            not isinstance(model._cuda_device, list),
-            "Error: Edge-probing does not currently work with Multi-GPU",
-        )
         module = EdgeClassifierModule(task, d_sent, task_params)
         setattr(model, "%s_mdl" % task.name, module)
     elif isinstance(task, Seq2SeqTask):

--- a/jiant/modules/edge_probing.py
+++ b/jiant/modules/edge_probing.py
@@ -165,7 +165,6 @@ class EdgeClassifierModule(nn.Module):
             out["loss"] = self.compute_loss(logits[span_mask], batch["labels"][span_mask], task)
 
         if predict:
-            # Return preds as a list.
             out["preds"] = self.get_predictions(logits)
 
         return out

--- a/jiant/tasks/edge_probing.py
+++ b/jiant/tasks/edge_probing.py
@@ -177,13 +177,18 @@ class EdgeProbingTask(Task):
         self.f1_scorer(binary_scores, labels)
 
     def handle_preds(self, preds, batch):
-        """ Unpack preds to varying-length numpy arrays.
+        """Unpack preds into varying-length numpy arrays, return the non-masked preds in a list.
 
-        Args:
-            preds: [batch_size, num_targets, ...]
+        Parameters
+        ----------
+            preds : [batch_size, num_targets, ...]
+            batch : dict
+                dict with key "span1s" having val w/ bool Tensor dim [batch_size, num_targets, ...].
 
-        Returns:
-            np.ndarray for each row of preds, selected by the corresponding row of span_mask.
+        Returns
+        -------
+            non_masked_preds : list[np.ndarray]
+                list of of pred np.ndarray selected by the corresponding row of span_mask.
 
         """
         masks = batch["span1s"][:, :, 0] != -1


### PR DESCRIPTION
This PR builds on #1025 "Fixing Edge-Probing after muti-GPU release".

**Important notes:**
1. w/ these changes `forward()` won't put `n_inputs` into model `out`. `n_inputs` does not appear to be accessed in the project, and leaving it in would require special handling for multi-GPU. 
2. the prediction processing functionality from `unbind_predictions` (a method of the edge probing module) is being moved to the `EdgeProbingTask`'s `handle_preds` method (a method of the parent `Task` for "task-specific processing of predictions",  introduced w/ #992).