### PR TITLE
fix mirrored pair input

### DIFF
--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -115,7 +115,7 @@ def process_single_pair_task_split(
                 model_preprocessing_interface.model_flags["uses_mirrored_pair"]
                 and is_symmetrical_pair
             ):
-                inp_m = model_preprocessing_interface.boundary_token_fn(input1, input2)
+                inp_m = model_preprocessing_interface.boundary_token_fn(input2, input1)
                 d["inputs_m"] = sentence_to_text_field(inp_m, indexers)
         else:
             d["input1"] = sentence_to_text_field(


### PR DESCRIPTION
When discussion with Phil about the preprocess function, I found I wrote a typo when implementing the preprocessing of gpt2-like single directional model.

This will have slight negatively affect on the performance of gpt, gpt2 and transformer-xl on sts-b, mrpc, qqp. But not other transformer models or other tasks. 