### PR TITLE
Add test and documentation guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,18 @@ Please review the guidelines below before opening a PR.
     2. Run formatting tests locally with `black {source_file_or_dir}`, or, after installing all jiant requirements and activating the environment, you can run `pre-commit install` so that black checking and reformatting runs automatically before committing your staged changes.
     3. For involved changes, run a minimal experiment (e.g., with “max_vals=1 and val_interval=10”) to check that your changes don’t break at runtime.
 6. Once your PR is ready for review, in your Draft PR press “Ready for review”. This will invite code owners to provide reviews, and makes the branch mergeable.
+
+### Test and documentation guidelines
+1. Tests: Test coverage and testing methods are expected to vary by PR. Test plans should be proposed/discussed early in the PR process. Except in special cases...
+     * Bug fixes should be paired with a test and/or other validations demonstrating that the bug has been squashed.
+     * Changes introducing a new feature should come with related unit tests.
+     * Changes introducing a new task should come with performance benchmark tests demonstrating that the code can roughly reproduce published performance numbers for that task.
+     * Changes to existing code are expected to come with some documented effort to test for related regressions. In cases where changes affect code that does not have high test coverage, this might involve designing validations and documenting them in the PR thread. If you’re unsure what validations are necessary, ping a code owner for guidance.
+2. Documentation: Public functions and methods should be documented with [numpy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html). If you’re making a major change to a public function/method that does not already have a docstring, you should add one.
+
+### Additional guidelines and helpful reminders for specific types of PRs:
+* For PRs that change package dependencies, update both `environment.yml` (used for conda) and `setup.py` (used by pip, and in automatic CircleCI tests).
+* For all PRs, make sure to update any existing config files, tutorials, and scripts to match your changes.
+* For PRs that typical users will need to be aware of, make a matching PR to the [documentation](https://github.com/nyu-mll/jiant-site/edit/master/documentation/README.md). We will merge that documentation PR once the original PR is merged in and pushed out in a release. (Proposals for better ways to do this are welcome.)
+* For PRs that add a new model or task, explain what types of sentence encoders are supported for that task.
+* For PRs that could change performance across multiple tasks, run performance regression tests on at least one representative task from each “family” of tasks. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please review the guidelines below before opening a PR.
     3. For involved changes, run a minimal experiment (e.g., with “max_vals=1 and val_interval=10”) to check that your changes don’t break at runtime.
 6. Once your PR is ready for review, in your Draft PR press “Ready for review”. This will invite code owners to provide reviews, and makes the branch mergeable.
 
-### Test and documentation guidelines
+### Test and documentation guidelines:
 1. Tests: Test coverage and testing methods are expected to vary by PR. Test plans should be proposed/discussed early in the PR process. Except in special cases...
      * Bug fixes should be paired with a test and/or other validations demonstrating that the bug has been squashed.
      * Changes introducing a new feature should come with related unit tests.
@@ -28,4 +28,4 @@ Please review the guidelines below before opening a PR.
 * For all PRs, make sure to update any existing config files, tutorials, and scripts to match your changes.
 * For PRs that typical users will need to be aware of, make a matching PR to the [documentation](https://github.com/nyu-mll/jiant-site/edit/master/documentation/README.md). We will merge that documentation PR once the original PR is merged in and pushed out in a release. (Proposals for better ways to do this are welcome.)
 * For PRs that add a new model or task, explain what types of sentence encoders are supported for that task.
-* For PRs that could change performance across multiple tasks, run performance regression tests on at least one representative task from each “family” of tasks. 
+* For PRs that could change performance across multiple tasks, run performance regression tests on at least one representative task from each “family” of tasks.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ For a full system overview of `jiant` version 1.3.0, see https://arxiv.org/abs/2
 
 To find the setup instructions for using jiant and to run a simple example demo experiment using data from GLUE, follow this [getting started tutorial](https://github.com/nyu-mll/jiant/tree/master/tutorials/setup_tutorial.md)!
 
+
+## Contributing
+Guidelines for contributing to `jiant` are available [here](CONTRIBUTING.md).
+
+
 ## Official Documentation
 
 Our official documentation is here: https://jiant.info/documentation#/

--- a/README.md
+++ b/README.md
@@ -74,18 +74,6 @@ For the [BERT NPI paper](https://arxiv.org/abs/1909.02597) follow the instructio
 Post an issue here on GitHub if you have any problems, and create a pull request if you make any improvements (substantial or cosmetic) to the code that you're willing to share.
 
 
-## Contributing
-
-We use the `black` coding style with a line limit of 100. After installing the requirements, simply running `pre-commit
-install` should ensure you comply with this in all your future commits. If you're adding features or fixing a bug,
-please also add the tests.
-
-For any PR, make sure to update any existing `conf` files, tutorials, and scripts to match your changes. If your PR adds or changes functionality that can be directly tested, add or update a test.
-
-For PRs that typical users will need to be aware of, include  make a matching PR to the [documentation](https://github.com/nyu-mll/jiant-site/edit/master/documentation/README.md). We will merge that documentation PR once the original PR is merged in _and pushed out in a release_. (Proposals for better ways to do this are welcome.)
-
-For PRs that change package dependencies, update both `environment.yml` (used for conda) and `setup.py` (used by pip, and in automatic CircleCI tests).
-
 ## Releases
 
 Releases are identified using git tags and distributed via PyPI for pip installation. After passing CI tests and creating a new git tag for a release, it can be uploaded to PyPI by running:


### PR DESCRIPTION
Adds test and documentation guidelines to `CONTRIBUTING.md`, and removes redundant contributing guidelines from `README.md`.