### PR TITLE
[WIP] Task load_data refactor

### DIFF
--- a/jiant/tasks/tasks.py
+++ b/jiant/tasks/tasks.py
@@ -490,6 +490,7 @@ class SSTTask(SingleClassificationTask):
 
         Note
         ----
+        After calling this method the task's attributes will have the following contents:
         self.train_data_text : List[List[Union[List[str], int]]]
             this field is set to a list of lists with dimension 3 x num_training_examples:
                   - self.train_data_text[0] : List[List[str]]


### PR DESCRIPTION
This PR demos a refactor of a task's `load_data` method (using`sst` as an example task). If these changes are acceptable, similar changes can be made to other tasks that currently use [`load_tsv`](https://github.com/nyu-mll/jiant/blob/61440732f4df2c54e68e59ead34b8656bf52af3b/jiant/utils/data_loaders.py#L79-L199).

Changes:
1. remove dependency on [`load_tsv`](https://github.com/nyu-mll/jiant/blob/61440732f4df2c54e68e59ead34b8656bf52af3b/jiant/utils/data_loaders.py#L79-L199) for improved readability/debugging.
2. add docstring documenting expected result of calling `load_data`.


**How was this tested?** These changes were tested by creating a mini task datasets (first 20 lines from each of the task's train, val, and test datasets), then...
1. On the master branch `load_data` was called and the results  were pickled; 
2. This PR branch was checked out and `load_data` was called again using the same data, and the result were compared (`assertSequenceEqual`) to the pickled object produced in step 1.  