### PR TITLE
Fix number of training examples in target training

### DIFF
--- a/jiant/trainer.py
+++ b/jiant/trainer.py
@@ -338,11 +338,10 @@ class SamplingMultiTaskTrainer:
             task_info["tr_generator"] = iterator(task.train_data, num_epochs=None)
 
             n_training_examples = task.n_train_examples
-            if phase == "pretrain":
-                # Warning: This won't be precise when training_data_fraction is set, since each
-                #  example is included or excluded independently using a hashing function.
-                # Fortunately, it doesn't need to be.
-                n_training_examples *= self._training_data_fraction
+            # Warning: This won't be precise when training_data_fraction is set, since each
+            #  example is included or excluded deterministically using a hashing function.
+            # See read_records function in serialize.py for details.
+            n_training_examples *= self._training_data_fraction
             task_info["n_tr_batches"] = math.ceil(n_training_examples / batch_size)
             task_info["n_tr_steps"] = math.ceil(
                 task_info["n_tr_batches"] / self._accumulation_steps


### PR DESCRIPTION
Now target_train_data_fraction will correctly affect the number of training examples in trainer, and logging and scheduler that depend on it. 

We will need this merged before running the 5k probing tasks in taskmaster.