### PR TITLE
Remove --remote_log from exp_fns.sh

### DIFF
--- a/scripts/edgeprobing/exp_fns.sh
+++ b/scripts/edgeprobing/exp_fns.sh
@@ -25,7 +25,7 @@ function run_exp() {
     OVERRIDES=$2
     declare -a args
     args+=( --config_file "${CONFIG_FILE}" )
-    args+=( -o "${OVERRIDES}" --remote_log )
+    args+=( -o "${OVERRIDES}" )
     if [ ! -z $NOTIFY_EMAIL ]; then
         args+=( --notify "$NOTIFY_EMAIL" )
     fi


### PR DESCRIPTION
Allow running these if not on GCP. The log should still be in a text file in the console.

If running on Kubernetes, this flag doesn't matter anyway since k8s does its own log management.