### PR TITLE
Fix git clone in example notebooks 

### DIFF
--- a/examples/notebooks/jiant_Basic_Example.ipynb
+++ b/examples/notebooks/jiant_Basic_Example.ipynb
@@ -55,10 +55,8 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "!cd jiant\n",
-    "!git checkout d26c213c742d36f8909f3a910694c8a90da416f1\n",
-    "!cd .."
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
    ]
   },
   {

--- a/examples/notebooks/jiant_MNLI_Diagnostic_Example.ipynb
+++ b/examples/notebooks/jiant_MNLI_Diagnostic_Example.ipynb
@@ -41,10 +41,8 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "!cd jiant\n",
-    "!git checkout d26c213c742d36f8909f3a910694c8a90da416f1\n",
-    "!cd .."
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
    ]
   },
   {

--- a/examples/notebooks/jiant_Multi_Task_Example.ipynb
+++ b/examples/notebooks/jiant_Multi_Task_Example.ipynb
@@ -59,10 +59,8 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "!cd jiant\n",
-    "!git checkout d26c213c742d36f8909f3a910694c8a90da416f1\n",
-    "!cd .."
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
    ]
   },
   {

--- a/examples/notebooks/jiant_STILTs_Example.ipynb
+++ b/examples/notebooks/jiant_STILTs_Example.ipynb
@@ -61,10 +61,8 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "!cd jiant\n",
-    "!git checkout d26c213c742d36f8909f3a910694c8a90da416f1\n",
-    "!cd .."
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
    ]
   },
   {

--- a/examples/notebooks/jiant_XNLI_Example.ipynb
+++ b/examples/notebooks/jiant_XNLI_Example.ipynb
@@ -62,10 +62,8 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "!cd jiant\n",
-    "!git checkout d26c213c742d36f8909f3a910694c8a90da416f1\n",
-    "!cd .."
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
    ]
   },
   {

--- a/examples/notebooks/simple_api_fine_tuning.ipynb
+++ b/examples/notebooks/simple_api_fine_tuning.ipynb
@@ -45,10 +45,8 @@
    },
    "source": [
     "%%capture\n",
-    "!git clone https://github.com/jiant-dev/jiant.git\n",
-    "%cd jiant\n",
-    "!git checkout 572441964e859d00fa2071c0888dd4ab6a8d3619\n",
-    "%cd ..\n",
+    "!git clone https://github.com/nyu-mll/jiant.git\n",
+    "%cd jiant && git checkout tags/2.0.0"
     "\n",
     "# This Colab notebook already has its CUDA-runtime compatible versions of torch and torchvision installed\n",
     "!pip install -r jiant/requirements-no-torch.txt\n",

--- a/examples/notebooks/simple_api_fine_tuning.ipynb
+++ b/examples/notebooks/simple_api_fine_tuning.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "%%capture\n",
     "!git clone https://github.com/nyu-mll/jiant.git\n",
-    "%cd jiant && git checkout tags/2.0.0"
+    "%cd jiant && git checkout tags/2.0.0",
     "\n",
     "# This Colab notebook already has its CUDA-runtime compatible versions of torch and torchvision installed\n",
     "!pip install -r jiant/requirements-no-torch.txt\n",


### PR DESCRIPTION
This PR updates the example notebooks to point at the `nyu-mll/jiant` 2.0.0 release.