### PR TITLE
Fix tokenization for arc_easy and arc_challenge

### DIFF
--- a/jiant/tasks/lib/arc_challenge.py
+++ b/jiant/tasks/lib/arc_challenge.py
@@ -61,7 +61,7 @@ class ArcChallengeTask(mc_template.AbstractMultipleChoiceTask):
             label = line["answerKey"]
             if label in potential_label_map:
                 label = potential_label_map[label]
-            choice_list = [d["text"] for d in line["question"]["choices"]]
+            choice_list = [d for d in line["choices"]["text"]]
             filler_choice_list = ["." for i in range(NUM_CHOICES - len(choice_list))]
             choice_list = choice_list + filler_choice_list
             assert len(choice_list) == NUM_CHOICES
@@ -69,7 +69,7 @@ class ArcChallengeTask(mc_template.AbstractMultipleChoiceTask):
             examples.append(
                 Example(
                     guid="%s-%s" % (set_type, i),
-                    prompt=line["question"]["stem"],
+                    prompt=line["question"],
                     choice_list=choice_list,
                     label=label,
                 )

--- a/jiant/tasks/lib/arc_easy.py
+++ b/jiant/tasks/lib/arc_easy.py
@@ -61,7 +61,7 @@ class ArcEasyTask(mc_template.AbstractMultipleChoiceTask):
             label = line["answerKey"]
             if label in potential_label_map:
                 label = potential_label_map[label]
-            choice_list = [d["text"] for d in line["question"]["choices"]]
+            choice_list = [d for d in line["choices"]["text"]]
             filler_choice_list = ["." for i in range(NUM_CHOICES - len(choice_list))]
             choice_list = choice_list + filler_choice_list
             assert len(choice_list) == NUM_CHOICES
@@ -69,7 +69,7 @@ class ArcEasyTask(mc_template.AbstractMultipleChoiceTask):
             examples.append(
                 Example(
                     guid="%s-%s" % (set_type, i),
-                    prompt=line["question"]["stem"],
+                    prompt=line["question"],
                     choice_list=choice_list,
                     label=label,
                 )


### PR DESCRIPTION
This PR fixes a tokenization issue for `arc_easy` and `arc_challenge` datasets. It seems there are some changes in format when using `datasets`. Tested and ran successfully with `roberta-large` using the following command:

```
python ${JIANT_PATH}/proj/main/tokenize_and_cache.py \
    		--task_config_path ${DATA_DIR}/configs/${TASK_NAME}_config.json \
    		--model_type ${MODEL_NAME} \
    		--model_tokenizer_path ${MODELS_DIR}/${MODEL_NAME}/tokenizer \
    		--phases train,val,test \
    		--max_seq_length 256 \
    		--do_iter \
    		--smart_truncate \
    		--output_dir ${CACHE_DIR}/${MODEL_NAME}/${TASK_NAME}
```