### PR TITLE
Add docs for adding tasks to data downloader

### DIFF
--- a/guides/tasks/adding_tasks.md
+++ b/guides/tasks/adding_tasks.md
@@ -162,8 +162,45 @@ def get_evaluation_scheme_for_task(task) -> BaseEvaluationScheme:
         return SimpleAccuracyEvaluationScheme()
 ```
 
-## 4. Update the supported tasks documentation
+## 4. Add a data downloader
+If your task is publicly available, add the task to the data downloader in [`jiant/scripts/download_data/runscript.py`](../../jiant/scripts/download_data/runscript.py). There are two flavors of downloading tasks:
+
+1) If the task is supported by Hugging Face's [Datasets](https://huggingface.co/nlp/viewer/):
+    - Add the task to `OTHER_HF_DATASETS_TASKS` in [`jiant/scripts/download_data/constants.py`](../../jiant/scripts/download_data/constants.py). Also add the task to `HF_DATASETS_CONVERSION_DICT` in [`jiant/scripts/download_data/dl_datasets/hf_datasets_tasks.py`](../../jiant/scripts/download_data/dl_datasets/hf_datasets_tasks.py). `HF_DATASETS_CONVERSION_DICT` is used to map field changes in Dataset's to the original dataset.
+
+2) If the task is not supported by Hugging Face's Datasets, and the dataset is publicly available for download:
+    - Add a function to directly download the task here: [`jiant/scripts/download_data/dl_datasets/files_tasks.py`](../../jiant/scripts/download_data/dl_datasets/files_tasks.py). The function signature should be similar to:
+
+```python
+def download_your_task_data_and_write_config(
+    task_name: str, task_data_path: str, task_config_path: str
+)
+```
+
+The direct download function for your task should generate output a config object to `task_config_path` based on the data required to complete the task. Depending on the requirements of your task, this looks something like:
+
+```python
+py_io.write_json(
+    data={
+        "task": task_name,
+        "paths": {
+            "train": os.path.join(task_data_path, "train.jsonl"),
+            "val": os.path.join(task_data_path, "valid.jsonl"),
+            "test": os.path.join(task_data_path, "tests.jsonl"),
+        },
+        "name": task_name,
+    },
+    path=task_config_path,
+)
+```
+
+## 5. Update the supported tasks documentation
 Add your task to [`guides/tasks/supported_tasks.md`](../../guides/tasks/supported_tasks.md).
+
+
+## 6. Tag the creator in the pull request
+Please @ the creator of the task in your PR to let them know it is part of `jiant`! This also gives them a chance to review the task.
+
 
 ## Congratulations!
 And that’s it. You’ve made all the core code changes required to include the `SentevalTenseTask` in your `jiant` experiments.

--- a/guides/tasks/adding_tasks.md
+++ b/guides/tasks/adding_tasks.md
@@ -163,32 +163,32 @@ def get_evaluation_scheme_for_task(task) -> BaseEvaluationScheme:
 ```
 
 ## 4. Add a data downloader
-If your task is publicly available, add the task to the data downloader in [`jiant/scripts/download_data/runscript.py`](../../jiant/scripts/download_data/runscript.py). There are two flavors of downloading tasks:
+If the new task is publicly available, add the new task to the data downloader in [`jiant/scripts/download_data/runscript.py`](../../jiant/scripts/download_data/runscript.py). There are two flavors of supported task downloaders:
 
-1) If the task is supported by Hugging Face's [Datasets](https://huggingface.co/nlp/viewer/):
+1) If the new task is supported by Hugging Face's [Datasets](https://huggingface.co/nlp/viewer/):
     - Add the task to `OTHER_HF_DATASETS_TASKS` in [`jiant/scripts/download_data/constants.py`](../../jiant/scripts/download_data/constants.py). Also add the task to `HF_DATASETS_CONVERSION_DICT` in [`jiant/scripts/download_data/dl_datasets/hf_datasets_tasks.py`](../../jiant/scripts/download_data/dl_datasets/hf_datasets_tasks.py). `HF_DATASETS_CONVERSION_DICT` is used to map field changes in Dataset's to the original dataset.
 
-2) If the task is not supported by Hugging Face's Datasets, and the dataset is publicly available for download:
+2) If the new task is not supported by Hugging Face's Datasets, and the dataset is publicly available for download:
     - Add a function to directly download the task here: [`jiant/scripts/download_data/dl_datasets/files_tasks.py`](../../jiant/scripts/download_data/dl_datasets/files_tasks.py). The function signature should be similar to:
 
 ```python
-def download_your_task_data_and_write_config(
+def download_senteval_data_and_write_config(
     task_name: str, task_data_path: str, task_config_path: str
 )
 ```
 
-The direct download function for your task should generate output a config object to `task_config_path` based on the data required to complete the task. Depending on the requirements of your task, this looks something like:
+The direct download function for your task should generate output a config object to `task_config_path` based on the data required to complete the task. For Senteval, the task config object is:
 
 ```python
 py_io.write_json(
     data={
-        "task": task_name,
+        "task": "senteval",
         "paths": {
             "train": os.path.join(task_data_path, "train.jsonl"),
             "val": os.path.join(task_data_path, "valid.jsonl"),
             "test": os.path.join(task_data_path, "tests.jsonl"),
         },
-        "name": task_name,
+        "name": "senteval",
     },
     path=task_config_path,
 )

--- a/guides/tasks/supported_tasks.md
+++ b/guides/tasks/supported_tasks.md
@@ -70,6 +70,7 @@
 | TyDiQA | `tydiqa_{lang}` | ✅ | ✅ | tydiqa | XTREME, multi-lang |
 | UDPOS | `udpos_{lang}` | ✅ | ✅ | udpos | XTREME, multi-lang |
 | WiC | wic | ✅ | ✅ | wic | SuperGLUE |
+| Winogrande | winogrande | ✅ | ✅ | winogrande | |
 | WNLI | wnli | ✅ | ✅ | wnli | GLUE |
 | WSC | wsc | ✅ | ✅ | wsc | SuperGLUE |
 | XNLI | `xnli_{lang}` | ✅ | ✅ | xnli | XTREME, multi-lang |

--- a/jiant/scripts/download_data/constants.py
+++ b/jiant/scripts/download_data/constants.py
@@ -18,3 +18,17 @@ OTHER_DOWNLOAD_TASKS = {
 DIRECT_DOWNLOAD_TASKS = set(
     list(SQUAD_TASKS) + list(DIRECT_SUPERGLUE_TASKS_TO_DATA_URLS) + list(OTHER_DOWNLOAD_TASKS)
 )
+OTHER_HF_DATASETS_TASKS = {
+    "snli",
+    "commonsenseqa",
+    "hellaswag",
+    "cosmosqa",
+    "socialiqa",
+    "scitail",
+    "quoref",
+    "adversarial_nli_r1",
+    "adversarial_nli_r2",
+    "adversarial_nli_r3",
+    "arc_easy",
+    "arc_challenge",
+}

--- a/jiant/scripts/download_data/runscript.py
+++ b/jiant/scripts/download_data/runscript.py
@@ -8,11 +8,14 @@ import jiant.scripts.download_data.dl_datasets.files_tasks as files_tasks_downlo
 from jiant.tasks.constants import (
     GLUE_TASKS,
     SUPERGLUE_TASKS,
-    OTHER_HF_DATASETS_TASKS,
     XTREME_TASKS,
     BENCHMARKS,
 )
-from jiant.scripts.download_data.constants import SQUAD_TASKS, DIRECT_DOWNLOAD_TASKS
+from jiant.scripts.download_data.constants import (
+    SQUAD_TASKS,
+    DIRECT_DOWNLOAD_TASKS,
+    OTHER_HF_DATASETS_TASKS,
+)
 
 # DIRECT_DOWNLOAD_TASKS need to be directly downloaded because the HF Datasets
 # implementation differs from the original dataset format

--- a/jiant/tasks/constants.py
+++ b/jiant/tasks/constants.py
@@ -25,21 +25,6 @@ SUPERGLUE_TASKS = {
     "superglue_winogender_diagnostics",
 }
 
-OTHER_HF_DATASETS_TASKS = {
-    "snli",
-    "commonsenseqa",
-    "hellaswag",
-    "cosmosqa",
-    "socialiqa",
-    "scitail",
-    "quoref",
-    "adversarial_nli_r1",
-    "adversarial_nli_r2",
-    "adversarial_nli_r3",
-    "arc_easy",
-    "arc_challenge",
-}
-
 XTREME_TASKS = {
     "xnli",
     "pawsx",

--- a/jiant/tasks/lib/mcscript.py
+++ b/jiant/tasks/lib/mcscript.py
@@ -7,7 +7,9 @@ from jiant.utils.python.io import read_json_lines
 
 @dataclass
 class Example(mc_template.Example):
-    pass
+    @property
+    def task(self):
+        return MCScriptTask
 
 
 @dataclass


### PR DESCRIPTION
This PR adds documentation for:

1. Adding a task to the data downloader (now required when adding a task)
2. @ the creator of a task when opening a PR adding a task