### PR TITLE
use task_name instead of task.name

### DIFF
--- a/jiant/proj/main/components/container_setup.py
+++ b/jiant/proj/main/components/container_setup.py
@@ -1,6 +1,6 @@
+import warnings
 from dataclasses import dataclass
 from typing import Dict, List, Optional
-
 
 import jiant.proj.main.components.task_sampler as jiant_task_sampler
 import jiant.shared.caching as caching
@@ -69,10 +69,17 @@ def create_task_dict(task_config_dict: dict, verbose: bool = True) -> Dict[str, 
         Dict mapping from task name to task instance.
 
     """
-    task_dict = {
-        task_name: tasks.create_task_from_config_path(config_path=task_config_path, verbose=False)
-        for task_name, task_config_path in task_config_dict.items()
-    }
+    task_dict = {}
+    for task_name, task_config_path in task_config_dict.items():
+        task = tasks.create_task_from_config_path(config_path=task_config_path, verbose=False)
+        if not task.name == task_name:
+            warnings.warn(
+                "task {} from {} has conflicting names: {}/{}. Using {}".format(
+                    task_name, task_config_path, task_name, task.name, task_name,
+                )
+            )
+            task.name = task_name
+        task_dict[task_name] = task
     if verbose:
         print("Creating Tasks:")
         for task_name, task_config_path in task_config_dict.items():


### PR DESCRIPTION
There are two sources of task names in `jiant`.

1. The task-names provided in the `task_name`->`task` mapping from the `task_config_dict`
2. The `task.name`, which is derived from the task config.

In all parts of the `jiant` training/eval loop, we use `task_name`, including for creating the models. The one exception is the runner calling the model, where we use the task object (and hence `task.name`).

To resolve this conflict, we will assign the `task.name = task_name` and throw a warning if they do not agree.