### PR TITLE
SQuAD update

### DIFF
--- a/jiant/scripts/download_data/dl_datasets/files_tasks.py
+++ b/jiant/scripts/download_data/dl_datasets/files_tasks.py
@@ -93,7 +93,7 @@ def download_squad_data_and_write_config(
         data={
             "task": "squad",
             "paths": {"train": train_path, "val": val_path},
-            "version_2_with_negative": version_2_with_negative,
+            "kwargs": {"version_2_with_negative": version_2_with_negative},
             "name": task_name,
         },
         path=task_config_path,

--- a/jiant/tasks/lib/templates/squad_style/core.py
+++ b/jiant/tasks/lib/templates/squad_style/core.py
@@ -21,6 +21,9 @@ from jiant.utils.display import maybe_tqdm
 
 import logging
 
+# Store the tokenizers which insert 2 separators tokens
+MULTI_SEP_TOKENS_TOKENIZERS_SET = {"roberta", "camembert", "bart"}
+
 logger = logging.getLogger(__name__)
 
 
@@ -135,9 +138,13 @@ class Example(BaseExample):
             truncation=True,
             max_length=max_query_length,
         )
+
+        # Tokenizers who insert 2 SEP tokens in-between <context> & <question> need to have special handling
+        # in the way they compute mask of added tokens.
+        tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
         sequence_added_tokens = (
             tokenizer.max_len - tokenizer.max_len_single_sentence + 1
-            if "roberta" in str(type(tokenizer)) or "camembert" in str(type(tokenizer))
+            if tokenizer_type in MULTI_SEP_TOKENS_TOKENIZERS_SET
             else tokenizer.max_len - tokenizer.max_len_single_sentence
         )
         sequence_pair_added_tokens = tokenizer.max_len - tokenizer.max_len_sentences_pair

--- a/jiant/tasks/lib/templates/squad_style/core.py
+++ b/jiant/tasks/lib/templates/squad_style/core.py
@@ -139,7 +139,8 @@ class Example(BaseExample):
             max_length=max_query_length,
         )
 
-        # Tokenizers who insert 2 SEP tokens in-between <context> & <question> need to have special handling
+        # Tokenizers who insert 2 SEP tokens in-between <context> & <question>
+        #   need to have special handling
         # in the way they compute mask of added tokens.
         tokenizer_type = type(tokenizer).__name__.replace("Tokenizer", "").lower()
         sequence_added_tokens = (

--- a/jiant/tasks/lib/templates/squad_style/core.py
+++ b/jiant/tasks/lib/templates/squad_style/core.py
@@ -101,7 +101,17 @@ class Example(BaseExample):
         all_doc_tokens = []
         for (i, token) in enumerate(self.doc_tokens):
             orig_to_tok_index.append(len(all_doc_tokens))
-            sub_tokens = tokenizer.tokenize(token)
+            if tokenizer.__class__.__name__ in [
+                "RobertaTokenizer",
+                "LongformerTokenizer",
+                "BartTokenizer",
+                "RobertaTokenizerFast",
+                "LongformerTokenizerFast",
+                "BartTokenizerFast",
+            ]:
+                sub_tokens = tokenizer.tokenize(token, add_prefix_space=True)
+            else:
+                sub_tokens = tokenizer.tokenize(token)
             for sub_token in sub_tokens:
                 tok_to_orig_index.append(i)
                 all_doc_tokens.append(sub_token)


### PR DESCRIPTION
1. Fixes SQuAD v2 task config to properly supply kwargs
2. Update SQuAD tokenization logic based on https://github.com/huggingface/transformers/pull/7387 (and subsequently refactored in https://github.com/huggingface/transformers/pull/7970)

The summary for 2 is that previously (including in the Hugging Face implementation), the context was being tokenized per-word rather than as a string. This is problematic for tokenizers that treat start-of-word tokens differently. 

Although the cited PR states that there is a large performance improvement from this fix, I did not observe this myself in my testing (both in `jiant` as well as in the `transformers` examples). Both versions appeared to perform comparably.

For `jiant` users, this will impact tokenization, but training a fresh model for either old or new tokenization should both work. I recommended deleting and recreating any SQuAD-based caches. However, if you consistently use only the old tokenization caches, that should be fine too.

