### PR TITLE
Load only encoder weights

### DIFF
--- a/jiant/proj/main/modeling/model_setup.py
+++ b/jiant/proj/main/modeling/model_setup.py
@@ -214,10 +214,10 @@ def load_encoder_only(jiant_model, weights_dict):
     # 2. Handle taskmodel encoders:
     for taskmodel_key in jiant_model.task_to_taskmodel_map:
         for encoder_key in encoder_keys:
-            new_key = f"taskmodels.{taskmodel_key}.encoder.{encoder_key}"
+            new_key = f"taskmodels_dict.{taskmodel_key}.encoder.{encoder_key}"
             new_weights_dict[new_key] = weights_dict[new_key]
 
-    jiant_model.load_state_dict(new_weights_dict, strict=False)
+    mismatch = jiant_model.load_state_dict(new_weights_dict, strict=False)
     return
 
 

--- a/jiant/proj/main/modeling/model_setup.py
+++ b/jiant/proj/main/modeling/model_setup.py
@@ -200,7 +200,7 @@ def load_encoder_only(jiant_model, weights_dict):
         weights_dict (Dict): model weights.
 
     Returns:
-        Dict[str, List] containing lists of missing head weights or missing heads if any.
+        Dict[str, List] containing dropped keys
 
     """
     new_weights_dict = {}
@@ -218,7 +218,10 @@ def load_encoder_only(jiant_model, weights_dict):
             new_weights_dict[new_key] = weights_dict[new_key]
 
     mismatch = jiant_model.load_state_dict(new_weights_dict, strict=False)
-    return
+    assert not mismatch.unexpected_keys
+    return {
+        "dropped_keys": mismatch.missing_keys,
+    }
 
 
 def load_partial_heads(


### PR DESCRIPTION
#1193

I also found that loading only encoder weights (and randomly initializing the task heads), because of the final learned representation, it is not uncommon even for randomly initialized task heads to have very strong task performance.