### PR TITLE
quail fix

### DIFF
--- a/jiant/tasks/lib/quail.py
+++ b/jiant/tasks/lib/quail.py
@@ -33,7 +33,7 @@ class QuailTask(mc_template.AbstractMultipleChoiceTask):
     DataRow = DataRow
     Batch = Batch
 
-    CHOICE_KEYS = ["0", "1", "2", "3"]
+    CHOICE_KEYS = [0, 1, 2, 3]
     CHOICE_TO_ID, ID_TO_CHOICE = labels_to_bimap(CHOICE_KEYS)
     NUM_CHOICES = len(CHOICE_KEYS)
 
@@ -53,7 +53,7 @@ class QuailTask(mc_template.AbstractMultipleChoiceTask):
             examples.append(
                 Example(
                     guid="%s-%s" % (set_type, i),
-                    prompt=line["context"],
+                    prompt=line["context"] + " " + line["question"],
                     choice_list=[d for d in line["answers"]],
                     label=line["label"],
                 )


### PR DESCRIPTION
The previous version of quail did not add "question" into the input.

Dev set accuracy 0.522 (based on RoBERTa-base) according to this colab: https://colab.research.google.com/drive/1oKnMFzVJnhTt22pIJ_OQhFRehjQ1iw2a?usp=sharing

Currently looking into integrating HF datasets into quail with Clara.