### PR TITLE
Refactor get_output_from_encoder() to be member of JiantTaskModel

### DIFF
--- a/jiant/proj/main/modeling/primary.py
+++ b/jiant/proj/main/modeling/primary.py
@@ -164,7 +164,7 @@ class JiantTransformersModel(metaclass=abc.ABCMeta):
     def get_hidden_dropout_prob(self):
         return self.config.hidden_dropout_prob
 
-    def __call__(self, input_ids, segment_ids, input_mask, output_hidden_states=True):
+    def encode(self, input_ids, segment_ids, input_mask, output_hidden_states=True):
         output = self.forward(
             input_ids=input_ids,
             token_type_ids=segment_ids,

--- a/jiant/proj/main/modeling/taskmodels.py
+++ b/jiant/proj/main/modeling/taskmodels.py
@@ -78,7 +78,7 @@ class ClassificationModel(Taskmodel):
         super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(pooled=jiant_transformers_model_output.pooled)
@@ -98,7 +98,7 @@ class RegressionModel(Taskmodel):
         super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         # TODO: Abuse of notation - these aren't really logits  (issue #1187)
@@ -123,7 +123,7 @@ class MultipleChoiceModel(Taskmodel):
         choice_score_list = []
         jiant_transformers_model_output_other_ls = []
         for i in range(self.num_choices):
-            jiant_transformers_model_output = self.jiant_transformers_model(
+            jiant_transformers_model_output = self.jiant_transformers_model.encode(
                 input_ids=batch.input_ids[:, i],
                 segment_ids=batch.segment_ids[:, i],
                 input_mask=batch.input_mask[:, i],
@@ -174,7 +174,7 @@ class SpanComparisonModel(Taskmodel):
         Returns:
             TYPE: Description
         """
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(unpooled=jiant_transformers_model_output.unpooled, spans=batch.spans)
@@ -200,7 +200,7 @@ class SpanPredictionModel(Taskmodel):
         # we can guarantee the output distribution will only be non-zero at those dimensions.
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
@@ -225,7 +225,7 @@ class MultiLabelSpanComparisonModel(Taskmodel):
         super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(unpooled=jiant_transformers_model_output.unpooled, spans=batch.spans)
@@ -249,7 +249,7 @@ class TokenClassificationModel(Taskmodel):
         super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
@@ -272,7 +272,7 @@ class QAModel(Taskmodel):
         super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
         logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
@@ -300,7 +300,7 @@ class MLMModel(Taskmodel):
             tokenizer=tokenizer,
             do_mask=self.task.do_mask,
         )
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=masked_batch.input_ids,
             segment_ids=masked_batch.segment_ids,
             input_mask=masked_batch.input_mask,
@@ -322,7 +322,7 @@ class EmbeddingModel(Taskmodel):
         self.layer = kwargs["layer"]
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        jiant_transformers_model_output = self.jiant_transformers_model(
+        jiant_transformers_model_output = self.jiant_transformers_model.encode(
             input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
 

--- a/jiant/proj/main/modeling/taskmodels.py
+++ b/jiant/proj/main/modeling/taskmodels.py
@@ -1,22 +1,22 @@
 import abc
 
-from dataclasses import dataclass
-from typing import Any
-from typing import Callable
-
 import torch
 import torch.nn as nn
 
+from typing import Callable
+
 import jiant.proj.main.modeling.heads as heads
-from jiant.proj.main.components.outputs import LogitsOutput, LogitsAndLossOutput
+
+from jiant.proj.main.components.outputs import LogitsAndLossOutput
+from jiant.proj.main.components.outputs import LogitsOutput
 from jiant.utils.python.datastructures import take_one
-from jiant.shared.model_resolution import ModelArchitectures
+
 from jiant.tasks.core import TaskTypes
 
 
 class JiantTaskModelFactory:
     """This factory is used to create task models bundling the task,
-       encoder, and task head within the task model.
+       jiant_transformers_model, and task head within the task model.
 
     Attributes:
         registry (dict): Dynamic registry mapping task types to task models
@@ -44,16 +44,16 @@ class JiantTaskModelFactory:
 
     def __call__(cls, task, jiant_transformers_model, head, **kwargs):
         """This creates the TaskModel corresponding to the Task, abc.abstractmethod,
-            and encoder used.
+            and jiant_transformers_model used.
 
         Args:
             task (Task): Task
-            jiant_transformers_model (JiantTransformersModel): Encoder
+            jiant_transformers_model (JiantTransformersModel): jiant_transformers_model
             head (BaseHead): Task head
             **kwargs: Additional arguments for initializing TaskModel
 
         Returns:
-            TaskModel: Initialized task model bundling task, encoder, and head
+            TaskModel: Initialized task model bundling task, jiant_transformers_model, and head
         """
         taskmodel_class = cls.registry[task.TASK_TYPE]
         taskmodel = taskmodel_class(task, jiant_transformers_model, head, **kwargs)
@@ -61,10 +61,10 @@ class JiantTaskModelFactory:
 
 
 class Taskmodel(nn.Module, metaclass=abc.ABCMeta):
-    def __init__(self, task, encoder, head):
+    def __init__(self, task, jiant_transformers_model, head):
         super().__init__()
         self.task = task
-        self.encoder = encoder
+        self.jiant_transformers_model = jiant_transformers_model
         self.head = head
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
@@ -73,70 +73,75 @@ class Taskmodel(nn.Module, metaclass=abc.ABCMeta):
 
 @JiantTaskModelFactory.register(TaskTypes.CLASSIFICATION)
 class ClassificationModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.ClassificationHead, **kwargs):
+    def __init__(self, task, jiant_transformers_model, head: heads.ClassificationHead, **kwargs):
 
-        super().__init__(task=task, encoder=encoder, head=head)
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(pooled=encoder_output.pooled)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(pooled=jiant_transformers_model_output.pooled)
         if compute_loss:
             loss_fct = nn.CrossEntropyLoss()
             loss = loss_fct(logits.view(-1, self.head.num_labels), batch.label_id.view(-1),)
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.REGRESSION)
 class RegressionModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.RegressionHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.RegressionHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
         # TODO: Abuse of notation - these aren't really logits  (issue #1187)
-        logits = self.head(pooled=encoder_output.pooled)
+        logits = self.head(pooled=jiant_transformers_model_output.pooled)
         if compute_loss:
             loss_fct = nn.MSELoss()
             loss = loss_fct(logits.view(-1), batch.label.view(-1))
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.MULTIPLE_CHOICE)
 class MultipleChoiceModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.RegressionHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.RegressionHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
         self.num_choices = task.NUM_CHOICES
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        input_ids = batch.input_ids
-        segment_ids = batch.segment_ids
-        input_mask = batch.input_mask
-
         choice_score_list = []
-        encoder_output_other_ls = []
+        jiant_transformers_model_output_other_ls = []
         for i in range(self.num_choices):
-            encoder_output = get_output_from_encoder(
-                encoder=self.encoder,
-                input_ids=input_ids[:, i],
-                segment_ids=segment_ids[:, i],
-                input_mask=input_mask[:, i],
+            jiant_transformers_model_output = self.jiant_transformers_model(
+                input_ids=batch.input_ids[:, i],
+                segment_ids=batch.segment_ids[:, i],
+                input_mask=batch.input_mask[:, i],
             )
-            choice_score = self.head(pooled=encoder_output.pooled)
+            choice_score = self.head(pooled=jiant_transformers_model_output.pooled)
             choice_score_list.append(choice_score)
-            encoder_output_other_ls.append(encoder_output.other)
+            jiant_transformers_model_output_other_ls.append(jiant_transformers_model_output.other)
 
         reshaped_outputs = []
-        if encoder_output_other_ls[0]:
-            for j in range(len(encoder_output_other_ls[0])):
+        if jiant_transformers_model_output_other_ls[0]:
+            for j in range(len(jiant_transformers_model_output_other_ls[0])):
                 reshaped_outputs.append(
                     [
-                        torch.stack([misc[j][layer_i] for misc in encoder_output_other_ls], dim=1)
-                        for layer_i in range(len(encoder_output_other_ls[0][0]))
+                        torch.stack(
+                            [misc[j][layer_i] for misc in jiant_transformers_model_output_other_ls],
+                            dim=1,
+                        )
+                        for layer_i in range(len(jiant_transformers_model_output_other_ls[0][0]))
                     ]
                 )
             reshaped_outputs = tuple(reshaped_outputs)
@@ -155,32 +160,50 @@ class MultipleChoiceModel(Taskmodel):
 
 @JiantTaskModelFactory.register(TaskTypes.SPAN_COMPARISON_CLASSIFICATION)
 class SpanComparisonModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.SpanComparisonHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.SpanComparisonHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(unpooled=encoder_output.unpooled, spans=batch.spans)
+        """Summary
+
+        Args:
+            batch (TYPE): Description
+            tokenizer (TYPE): Description
+            compute_loss (bool, optional): Description
+
+        Returns:
+            TYPE: Description
+        """
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled, spans=batch.spans)
         if compute_loss:
             loss_fct = nn.CrossEntropyLoss()
             loss = loss_fct(logits.view(-1, self.head.num_labels), batch.label_id.view(-1),)
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.SPAN_PREDICTION)
 class SpanPredictionModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.TokenClassificationHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(
+        self, task, jiant_transformers_model, head: heads.TokenClassificationHead, **kwargs
+    ):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
         self.offset_margin = 1000
         # 1000 is a big enough number that exp(-1000) will be strict 0 in float32.
         # So that if we add 1000 to the valid dimensions in the input of softmax,
         # we can guarantee the output distribution will only be non-zero at those dimensions.
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(unpooled=encoder_output.unpooled)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
         # Ensure logits in valid range is at least self.offset_margin higher than others
         logits_offset = logits.max() - logits.min() + self.offset_margin
         logits = logits + logits_offset * batch.selection_token_mask.unsqueeze(dim=2)
@@ -189,71 +212,87 @@ class SpanPredictionModel(Taskmodel):
             loss = loss_fct(
                 logits.transpose(dim0=1, dim1=2).flatten(end_dim=1), batch.gt_span_idxs.flatten(),
             )
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.MULTI_LABEL_SPAN_CLASSIFICATION)
 class MultiLabelSpanComparisonModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.SpanComparisonHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.SpanComparisonHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(unpooled=encoder_output.unpooled, spans=batch.spans)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled, spans=batch.spans)
         if compute_loss:
             loss_fct = nn.BCEWithLogitsLoss()
             loss = loss_fct(logits.view(-1, self.head.num_labels), batch.label_ids.float(),)
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.TAGGING)
 class TokenClassificationModel(Taskmodel):
     """From RobertaForTokenClassification"""
 
-    def __init__(self, task, encoder, head: heads.TokenClassificationHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(
+        self, task, jiant_transformers_model, head: heads.TokenClassificationHead, **kwargs
+    ):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(unpooled=encoder_output.unpooled)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
         if compute_loss:
             loss_fct = nn.CrossEntropyLoss()
             active_loss = batch.label_mask.view(-1) == 1
             active_logits = logits.view(-1, self.head.num_labels)[active_loss]
             active_labels = batch.label_ids.view(-1)[active_loss]
             loss = loss_fct(active_logits, active_labels)
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.SQUAD_STYLE_QA)
 class QAModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.QAHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.QAHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(encoder=self.encoder, batch=batch)
-        logits = self.head(unpooled=encoder_output.unpooled)
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
+        )
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
         if compute_loss:
             loss = compute_qa_loss(
                 logits=logits,
                 start_positions=batch.start_position,
                 end_positions=batch.end_position,
             )
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.MASKED_LANGUAGE_MODELING)
 class MLMModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.BaseMLMHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.BaseMLMHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
 
     def forward(self, batch, tokenizer, compute_loss: bool = False):
         masked_batch = batch.get_masked(
@@ -261,33 +300,34 @@ class MLMModel(Taskmodel):
             tokenizer=tokenizer,
             do_mask=self.task.do_mask,
         )
-        encoder_output = get_output_from_encoder(
-            encoder=self.encoder,
-            input_ids=masked_batch.masked_input_ids,
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=masked_batch.input_ids,
             segment_ids=masked_batch.segment_ids,
             input_mask=masked_batch.input_mask,
         )
-        logits = self.head(unpooled=encoder_output.unpooled)
+        logits = self.head(unpooled=jiant_transformers_model_output.unpooled)
         if compute_loss:
             loss = compute_mlm_loss(logits=logits, masked_lm_labels=masked_batch.masked_lm_labels)
-            return LogitsAndLossOutput(logits=logits, loss=loss, other=encoder_output.other)
+            return LogitsAndLossOutput(
+                logits=logits, loss=loss, other=jiant_transformers_model_output.other
+            )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 @JiantTaskModelFactory.register(TaskTypes.EMBEDDING)
 class EmbeddingModel(Taskmodel):
-    def __init__(self, task, encoder, head: heads.AbstractPoolerHead, **kwargs):
-        super().__init__(task=task, encoder=encoder, head=head)
+    def __init__(self, task, jiant_transformers_model, head: heads.AbstractPoolerHead, **kwargs):
+        super().__init__(task=task, jiant_transformers_model=jiant_transformers_model, head=head)
         self.layer = kwargs["layer"]
 
-    def forward(self, batch, task, tokenizer, compute_loss: bool = False):
-        encoder_output = get_output_from_encoder_and_batch(
-            encoder_output=self.encoder, batch=batch, output_hidden_states=True
+    def forward(self, batch, tokenizer, compute_loss: bool = False):
+        jiant_transformers_model_output = self.jiant_transformers_model(
+            input_ids=batch.input_ids, segment_ids=batch.segment_ids, input_mask=batch.input_mask,
         )
 
         # A tuple of layers of hidden states
-        hidden_states = take_one(encoder_output.other)
+        hidden_states = take_one(jiant_transformers_model_output.other)
         layer_hidden_states = hidden_states[self.layer]
 
         if isinstance(self.head, heads.MeanPoolerHead):
@@ -303,149 +343,10 @@ class EmbeddingModel(Taskmodel):
             return LogitsAndLossOutput(
                 logits=logits,
                 loss=torch.tensor([0.0]),  # This is a horrible hack
-                other=encoder_output.other,
+                other=jiant_transformers_model_output.other,
             )
         else:
-            return LogitsOutput(logits=logits, other=encoder_output.other)
-
-
-@dataclass
-class EncoderOutput:
-
-    pooled: torch.Tensor
-    unpooled: torch.Tensor
-    other: Any = None
-    # Extend later with attention, hidden_acts, etc
-
-
-def get_output_from_encoder_and_batch(encoder, batch, output_hidden_states=False) -> EncoderOutput:
-    """Pass batch to encoder, return encoder model output.
-
-    Args:
-        encoder: bare model outputting raw hidden-states without any specific head.
-        batch: Batch object (containing token indices, token type ids, and attention mask).
-
-    Returns:
-        EncoderOutput containing pooled and unpooled model outputs as well as any other outputs.
-
-    """
-    return get_output_from_encoder(
-        encoder=encoder,
-        input_ids=batch.input_ids,
-        segment_ids=batch.segment_ids,
-        input_mask=batch.input_mask,
-        output_hidden_states=output_hidden_states,
-    )
-
-
-def get_output_from_encoder(
-    encoder, input_ids, segment_ids, input_mask, output_hidden_states=False
-) -> EncoderOutput:
-    """Pass inputs to encoder, return encoder output.
-
-    Args:
-        encoder: bare model outputting raw hidden-states without any specific head.
-        input_ids: token indices (see huggingface.co/transformers/glossary.html#input-ids).
-        segment_ids: token type ids (see huggingface.co/transformers/glossary.html#token-type-ids).
-        input_mask: attention mask (see huggingface.co/transformers/glossary.html#attention-mask).
-
-    Raises:
-        RuntimeError if encoder output contains less than 2 elements.
-
-    Returns:
-        EncoderOutput containing pooled and unpooled model outputs as well as any other outputs.
-
-    """
-    model_arch = ModelArchitectures.from_encoder(encoder)
-    if model_arch in [
-        ModelArchitectures.BERT,
-        ModelArchitectures.ROBERTA,
-        ModelArchitectures.ALBERT,
-        ModelArchitectures.XLM_ROBERTA,
-    ]:
-        pooled, unpooled, other = get_output_from_standard_transformer_models(
-            encoder=encoder,
-            input_ids=input_ids,
-            segment_ids=segment_ids,
-            input_mask=input_mask,
-            output_hidden_states=output_hidden_states,
-        )
-    elif model_arch == ModelArchitectures.ELECTRA:
-        pooled, unpooled, other = get_output_from_electra(
-            encoder=encoder,
-            input_ids=input_ids,
-            segment_ids=segment_ids,
-            input_mask=input_mask,
-            output_hidden_states=output_hidden_states,
-        )
-    elif model_arch in [
-        ModelArchitectures.BART,
-        ModelArchitectures.MBART,
-    ]:
-        pooled, unpooled, other = get_output_from_bart_models(
-            encoder=encoder,
-            input_ids=input_ids,
-            input_mask=input_mask,
-            output_hidden_states=output_hidden_states,
-        )
-    else:
-        raise KeyError(model_arch)
-
-    # Extend later with attention, hidden_acts, etc
-    if other:
-        return EncoderOutput(pooled=pooled, unpooled=unpooled, other=other)
-    else:
-        return EncoderOutput(pooled=pooled, unpooled=unpooled)
-
-
-def get_output_from_standard_transformer_models(
-    encoder, input_ids, segment_ids, input_mask, output_hidden_states=False
-):
-    output = encoder(
-        input_ids=input_ids,
-        token_type_ids=segment_ids,
-        attention_mask=input_mask,
-        output_hidden_states=output_hidden_states,
-    )
-    return output.pooler_output, output.last_hidden_state, output.hidden_states
-
-
-def get_output_from_bart_models(encoder, input_ids, input_mask, output_hidden_states=False):
-    # BART and mBART and encoder-decoder architectures.
-    # As described in the BART paper and implemented in Transformers,
-    # for single input tasks, the encoder input is the sequence,
-    # the decode input is 1-shifted sequence, and the resulting
-    # sentence representation is the final decoder state.
-    # That's what we use for `unpooled` here.
-    output = encoder(
-        input_ids=input_ids, attention_mask=input_mask, output_hidden_states=output_hidden_states,
-    )
-    dec_all = output.decoder_hidden_states
-    enc_all = output.encoder_hidden_states
-
-    unpooled = output
-
-    hidden_states = (enc_all + dec_all,)
-
-    bsize, slen = input_ids.shape
-    batch_idx = torch.arange(bsize).to(input_ids.device)
-    # Get last non-pad index
-    pooled = unpooled[batch_idx, slen - input_ids.eq(encoder.config.pad_token_id).sum(1) - 1]
-    return pooled, unpooled, hidden_states
-
-
-def get_output_from_electra(
-    encoder, input_ids, segment_ids, input_mask, output_hidden_states=False
-):
-    output = encoder(
-        input_ids=input_ids,
-        token_type_ids=segment_ids,
-        attention_mask=input_mask,
-        output_hidden_states=output_hidden_states,
-    )
-    unpooled = output.hidden_states
-    pooled = unpooled[:, 0, :]
-    return pooled, unpooled, output.hidden_states
+            return LogitsOutput(logits=logits, other=jiant_transformers_model_output.other)
 
 
 def compute_mlm_loss(logits, masked_lm_labels):

--- a/jiant/proj/simple/runscript.py
+++ b/jiant/proj/simple/runscript.py
@@ -213,7 +213,6 @@ def run_simple(args: RunConfiguration, with_continue: bool = False):
             output_dir=run_output_dir,
             # === Model parameters === #
             hf_pretrained_model_name_or_path=args.hf_pretrained_model_name_or_path,
-            model_type=hf_config.model_type,
             model_path=model_weights_path,
             model_config_path=os.path.join(
                 model_cache_path, hf_config.model_type, "model", f"{hf_config.model_type}.json"

--- a/requirements-no-torch.txt
+++ b/requirements-no-torch.txt
@@ -13,6 +13,6 @@ seqeval==0.0.12
 scikit-learn==0.22.2.post1
 scipy==1.4.1
 sentencepiece==0.1.86
-tokenizers==0.9.4
+tokenizers==0.10.1
 tqdm==4.46.0
 transformers==4.3.3

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "scikit-learn == 0.22.2.post1",
         "scipy == 1.4.1",
         "sentencepiece == 0.1.86",
-        "tokenizers == 0.9.4",
+        "tokenizers == 0.10.1",
         "torch >= 1.5.0",
         "tqdm == 4.46.0",
         "transformers == 4.3.3",

--- a/tests/proj/simple/test_runscript.py
+++ b/tests/proj/simple/test_runscript.py
@@ -8,7 +8,7 @@ import jiant.scripts.download_data.runscript as downloader
 import jiant.utils.torch_utils as torch_utils
 
 
-@pytest.mark.gpu
+@pytest.mark.slow
 @pytest.mark.parametrize("task_name", ["copa"])
 @pytest.mark.parametrize("model_type", ["bert-base-cased"])
 def test_simple_runscript(tmpdir, task_name, model_type):


### PR DESCRIPTION
These changes move the if-else statements (for `ModelArchitectures`) in `get_output_from_encoder()` to the newly added `JiantTransformersModel` when using `__call__`. 