### PR TITLE
Fix tasks circular import

### DIFF
--- a/jiant/proj/main/components/container_setup.py
+++ b/jiant/proj/main/components/container_setup.py
@@ -4,7 +4,8 @@ from typing import Dict, List, Optional
 
 import jiant.proj.main.components.task_sampler as jiant_task_sampler
 import jiant.shared.caching as caching
-import jiant.tasks as tasks
+from jiant.tasks.core import Task
+from jiant.tasks.retrieval import create_task_from_config_path
 import jiant.utils.python.io as py_io
 from jiant.utils.python.datastructures import ExtendedDataClassMixin
 
@@ -48,7 +49,7 @@ class TaskRunConfig(ExtendedDataClassMixin):
 
 @dataclass
 class JiantTaskContainer:
-    task_dict: Dict[str, tasks.Task]
+    task_dict: Dict[str, Task]
     task_sampler: jiant_task_sampler.BaseMultiTaskSampler
     task_cache_dict: Dict
     global_train_config: GlobalTrainConfig
@@ -58,7 +59,7 @@ class JiantTaskContainer:
     metrics_aggregator: jiant_task_sampler.BaseMetricAggregator
 
 
-def create_task_dict(task_config_dict: dict, verbose: bool = True) -> Dict[str, tasks.Task]:
+def create_task_dict(task_config_dict: dict, verbose: bool = True) -> Dict[str, Task]:
     """Make map of task name to task instances from map of task name to task config file paths.
 
     Args:
@@ -71,7 +72,7 @@ def create_task_dict(task_config_dict: dict, verbose: bool = True) -> Dict[str, 
     """
     task_dict = {}
     for task_name, task_config_path in task_config_dict.items():
-        task = tasks.create_task_from_config_path(config_path=task_config_path, verbose=False)
+        task = create_task_from_config_path(config_path=task_config_path, verbose=False)
         if not task.name == task_name:
             warnings.warn(
                 "task {} from {} has conflicting names: {}/{}. Using {}".format(

--- a/jiant/proj/main/modeling/model_setup.py
+++ b/jiant/proj/main/modeling/model_setup.py
@@ -16,7 +16,7 @@ from jiant.proj.main.modeling.heads import JiantHeadFactory
 from jiant.proj.main.modeling.taskmodels import JiantTaskModelFactory, Taskmodel, MLMModel
 
 from jiant.shared.model_resolution import ModelArchitectures
-from jiant.tasks import Task
+from jiant.tasks.core import Task
 
 
 def setup_jiant_model(

--- a/jiant/proj/main/tokenize_and_cache.py
+++ b/jiant/proj/main/tokenize_and_cache.py
@@ -1,15 +1,17 @@
 import os
 
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoConfig
+from transformers import AutoTokenizer
 
 import jiant.proj.main.preprocessing as preprocessing
 import jiant.shared.caching as shared_caching
-import jiant.tasks as tasks
 import jiant.tasks.evaluate as evaluate
-import jiant.utils.zconf as zconf
 import jiant.utils.python.io as py_io
-from jiant.shared.constants import PHASE
+import jiant.utils.zconf as zconf
+
 from jiant.proj.main.modeling.primary import JiantTransformersModelFactory
+from jiant.shared.constants import PHASE
+from jiant.tasks.retrieval import create_task_from_config_path
 
 
 @zconf.run_config
@@ -145,7 +147,7 @@ def main(args: RunConfiguration):
     config = AutoConfig.from_pretrained(args.hf_pretrained_model_name_or_path)
     model_type = config.model_type
 
-    task = tasks.create_task_from_config_path(config_path=args.task_config_path, verbose=True)
+    task = create_task_from_config_path(config_path=args.task_config_path, verbose=True)
     feat_spec = JiantTransformersModelFactory.build_featurization_spec(
         model_type=model_type, max_seq_length=args.max_seq_length,
     )

--- a/jiant/proj/simple/runscript.py
+++ b/jiant/proj/simple/runscript.py
@@ -103,7 +103,6 @@ def create_and_write_task_configs(task_name_list, data_dir, task_config_base_pat
 
 def run_simple(args: RunConfiguration, with_continue: bool = False):
     hf_config = AutoConfig.from_pretrained(args.hf_pretrained_model_name_or_path)
-
     model_cache_path = replace_none(
         args.model_cache_path, default=os.path.join(args.exp_dir, "models")
     )

--- a/jiant/tasks/__init__.py
+++ b/jiant/tasks/__init__.py
@@ -1,2 +1,0 @@
-from .retrieval import *  # noqa: F401,F403
-from .core import BatchMixin, TaskTypes  # noqa: F401

--- a/jiant/tasks/evaluate/core.py
+++ b/jiant/tasks/evaluate/core.py
@@ -1,26 +1,35 @@
 import itertools
 import json
+
 from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
 import seqeval.metrics as seqeval_metrics
 import torch
-from sklearn.metrics import f1_score, matthews_corrcoef
-from scipy.stats import pearsonr, spearmanr
-from typing import Dict, List
+
+from scipy.stats import pearsonr
+from scipy.stats import spearmanr
+from sklearn.metrics import f1_score
+from sklearn.metrics import matthews_corrcoef
+from typing import Dict
+from typing import List
 
 import jiant.shared.model_resolution as model_resolution
-import jiant.tasks as tasks
+
+import jiant.tasks.lib.bucc2018 as bucc2018_lib
+import jiant.tasks.lib.mlqa as mlqa_lib
+import jiant.tasks.lib.tatoeba as tatoeba_lib
 import jiant.tasks.lib.templates.squad_style.core as squad_style
 import jiant.tasks.lib.templates.squad_style.utils as squad_style_utils
-import jiant.tasks.lib.mlqa as mlqa_lib
-import jiant.tasks.lib.bucc2018 as bucc2018_lib
-import jiant.tasks.lib.tatoeba as tatoeba_lib
+
+import jiant.tasks.retrieval as tasks_retrieval
+
 from jiant.tasks.lib.templates import mlm as mlm_template
 from jiant.utils.python.datastructures import ExtendedDataClassMixin
 from jiant.utils.python.io import read_json
-from jiant.utils.string_comparing import string_f1_score, exact_match_score
+from jiant.utils.string_comparing import exact_match_score
+from jiant.utils.string_comparing import string_f1_score
 
 
 @dataclass
@@ -752,7 +761,7 @@ class XlingQAEvaluationScheme(BaseEvaluationScheme):
         self, task, accumulator: BaseAccumulator, tokenizer, labels
     ) -> Metrics:
         logits = accumulator.get_accumulated()
-        assert isinstance(task, (tasks.TyDiQATask, tasks.XquadTask))
+        assert isinstance(task, (tasks_retrieval.TyDiQATask, tasks_retrieval.XquadTask))
         lang = task.language
         results, predictions = squad_style.compute_predictions_logits_v3(
             data_rows=labels,
@@ -954,119 +963,119 @@ def get_evaluation_scheme_for_task(task) -> BaseEvaluationScheme:
     if isinstance(
         task,
         (
-            tasks.AdversarialNliTask,
-            tasks.AbductiveNliTask,
-            tasks.AcceptabilityDefinitenessTask,
-            tasks.AcceptabilityCoordTask,
-            tasks.AcceptabilityEOSTask,
-            tasks.AcceptabilityWHwordsTask,
-            tasks.BoolQTask,
-            tasks.CopaTask,
-            tasks.FeverNliTask,
-            tasks.MnliTask,
-            tasks.PawsXTask,
-            tasks.QnliTask,
-            tasks.RaceTask,
-            tasks.RteTask,
-            tasks.SciTailTask,
-            tasks.SentEvalBigramShiftTask,
-            tasks.SentEvalCoordinationInversionTask,
-            tasks.SentEvalObjNumberTask,
-            tasks.SentEvalOddManOutTask,
-            tasks.SentEvalPastPresentTask,
-            tasks.SentEvalSentenceLengthTask,
-            tasks.SentEvalSubjNumberTask,
-            tasks.SentEvalTopConstituentsTask,
-            tasks.SentEvalTreeDepthTask,
-            tasks.SentEvalWordContentTask,
-            tasks.SnliTask,
-            tasks.SstTask,
-            tasks.WiCTask,
-            tasks.WnliTask,
-            tasks.WSCTask,
-            tasks.XnliTask,
-            tasks.MCScriptTask,
-            tasks.ArctTask,
-            tasks.PiqaTask,
+            tasks_retrieval.AdversarialNliTask,
+            tasks_retrieval.AbductiveNliTask,
+            tasks_retrieval.AcceptabilityDefinitenessTask,
+            tasks_retrieval.AcceptabilityCoordTask,
+            tasks_retrieval.AcceptabilityEOSTask,
+            tasks_retrieval.AcceptabilityWHwordsTask,
+            tasks_retrieval.BoolQTask,
+            tasks_retrieval.CopaTask,
+            tasks_retrieval.FeverNliTask,
+            tasks_retrieval.MnliTask,
+            tasks_retrieval.PawsXTask,
+            tasks_retrieval.QnliTask,
+            tasks_retrieval.RaceTask,
+            tasks_retrieval.RteTask,
+            tasks_retrieval.SciTailTask,
+            tasks_retrieval.SentEvalBigramShiftTask,
+            tasks_retrieval.SentEvalCoordinationInversionTask,
+            tasks_retrieval.SentEvalObjNumberTask,
+            tasks_retrieval.SentEvalOddManOutTask,
+            tasks_retrieval.SentEvalPastPresentTask,
+            tasks_retrieval.SentEvalSentenceLengthTask,
+            tasks_retrieval.SentEvalSubjNumberTask,
+            tasks_retrieval.SentEvalTopConstituentsTask,
+            tasks_retrieval.SentEvalTreeDepthTask,
+            tasks_retrieval.SentEvalWordContentTask,
+            tasks_retrieval.SnliTask,
+            tasks_retrieval.SstTask,
+            tasks_retrieval.WiCTask,
+            tasks_retrieval.WnliTask,
+            tasks_retrieval.WSCTask,
+            tasks_retrieval.XnliTask,
+            tasks_retrieval.MCScriptTask,
+            tasks_retrieval.ArctTask,
+            tasks_retrieval.PiqaTask,
         ),
     ):
         return SimpleAccuracyEvaluationScheme()
-    elif isinstance(task, tasks.MCTACOTask):
+    elif isinstance(task, tasks_retrieval.MCTACOTask):
         return MCTACOEvaluationScheme()
-    elif isinstance(task, tasks.CCGTask):
+    elif isinstance(task, tasks_retrieval.CCGTask):
         return CCGEvaluationScheme()
-    elif isinstance(task, tasks.CommitmentBankTask):
+    elif isinstance(task, tasks_retrieval.CommitmentBankTask):
         return CommitmentBankEvaluationScheme()
-    elif isinstance(task, tasks.ColaTask):
+    elif isinstance(task, tasks_retrieval.ColaTask):
         return MCCEvaluationScheme()
     elif isinstance(
         task,
         (
-            tasks.ArcEasyTask,
-            tasks.ArcChallengeTask,
-            tasks.CommonsenseQATask,
-            tasks.CosmosQATask,
-            tasks.SWAGTask,
-            tasks.HellaSwagTask,
-            tasks.MutualTask,
-            tasks.MutualPlusTask,
-            tasks.QuailTask,
-            tasks.SocialIQATask,
-            tasks.WinograndeTask,
-            tasks.MCTestTask,
+            tasks_retrieval.ArcEasyTask,
+            tasks_retrieval.ArcChallengeTask,
+            tasks_retrieval.CommonsenseQATask,
+            tasks_retrieval.CosmosQATask,
+            tasks_retrieval.SWAGTask,
+            tasks_retrieval.HellaSwagTask,
+            tasks_retrieval.MutualTask,
+            tasks_retrieval.MutualPlusTask,
+            tasks_retrieval.QuailTask,
+            tasks_retrieval.SocialIQATask,
+            tasks_retrieval.WinograndeTask,
+            tasks_retrieval.MCTestTask,
         ),
     ):
         return MultipleChoiceAccuracyEvaluationScheme()
-    elif isinstance(task, (tasks.MrpcTask, tasks.QqpTask)):
+    elif isinstance(task, (tasks_retrieval.MrpcTask, tasks_retrieval.QqpTask)):
         return AccAndF1EvaluationScheme()
     elif isinstance(
         task,
         (
-            tasks.Spr1Task,
-            tasks.Spr2Task,
-            tasks.SemevalTask,
-            tasks.SrlTask,
-            tasks.NerTask,
-            tasks.CorefTask,
-            tasks.DprTask,
-            tasks.DepTask,
-            tasks.PosTask,
-            tasks.NonterminalTask,
+            tasks_retrieval.Spr1Task,
+            tasks_retrieval.Spr2Task,
+            tasks_retrieval.SemevalTask,
+            tasks_retrieval.SrlTask,
+            tasks_retrieval.NerTask,
+            tasks_retrieval.CorefTask,
+            tasks_retrieval.DprTask,
+            tasks_retrieval.DepTask,
+            tasks_retrieval.PosTask,
+            tasks_retrieval.NonterminalTask,
         ),
     ):
         return MultiLabelAccAndF1EvaluationScheme()
-    elif isinstance(task, tasks.ReCoRDTask):
+    elif isinstance(task, tasks_retrieval.ReCoRDTask):
         return ReCordEvaluationScheme()
     elif isinstance(
         task,
         (
-            tasks.SquadTask,
-            tasks.RopesTask,
-            tasks.QuorefTask,
-            tasks.NewsQATask,
-            tasks.MrqaNaturalQuestionsTask,
+            tasks_retrieval.SquadTask,
+            tasks_retrieval.RopesTask,
+            tasks_retrieval.QuorefTask,
+            tasks_retrieval.NewsQATask,
+            tasks_retrieval.MrqaNaturalQuestionsTask,
         ),
     ):
         return SQuADEvaluationScheme()
-    elif isinstance(task, (tasks.TyDiQATask, tasks.XquadTask)):
+    elif isinstance(task, (tasks_retrieval.TyDiQATask, tasks_retrieval.XquadTask)):
         return XlingQAEvaluationScheme()
-    elif isinstance(task, tasks.MlqaTask):
+    elif isinstance(task, tasks_retrieval.MlqaTask):
         return MLQAEvaluationScheme()
-    elif isinstance(task, tasks.MultiRCTask):
+    elif isinstance(task, tasks_retrieval.MultiRCTask):
         return MultiRCEvaluationScheme()
-    elif isinstance(task, tasks.StsbTask):
+    elif isinstance(task, tasks_retrieval.StsbTask):
         return PearsonAndSpearmanEvaluationScheme()
-    elif isinstance(task, tasks.MLMSimpleTask):
+    elif isinstance(task, tasks_retrieval.MLMSimpleTask):
         return MLMEvaluationScheme()
-    elif isinstance(task, (tasks.MLMPremaskedTask, tasks.MLMPretokenizedTask)):
+    elif isinstance(task, (tasks_retrieval.MLMPremaskedTask, tasks_retrieval.MLMPretokenizedTask)):
         return MLMPremaskedEvaluationScheme()
-    elif isinstance(task, (tasks.QAMRTask, tasks.QASRLTask)):
+    elif isinstance(task, (tasks_retrieval.QAMRTask, tasks_retrieval.QASRLTask)):
         return SpanPredictionF1andEMScheme()
-    elif isinstance(task, (tasks.UdposTask, tasks.PanxTask)):
+    elif isinstance(task, (tasks_retrieval.UdposTask, tasks_retrieval.PanxTask)):
         return F1TaggingEvaluationScheme()
-    elif isinstance(task, tasks.Bucc2018Task):
+    elif isinstance(task, tasks_retrieval.Bucc2018Task):
         return Bucc2018EvaluationScheme()
-    elif isinstance(task, tasks.TatoebaTask):
+    elif isinstance(task, tasks_retrieval.TatoebaTask):
         return TatoebaEvaluationScheme()
     else:
         raise KeyError(task)

--- a/tests/proj/main/test_export_model.py
+++ b/tests/proj/main/test_export_model.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from transformers import BertPreTrainedModel, BertTokenizer, RobertaForMaskedLM, RobertaTokenizer
+from transformers import BertPreTrainedModel, RobertaForMaskedLM, DebertaForMaskedLM
 
 import jiant.utils.python.io as py_io
 from jiant.proj.main.export_model import export_model

--- a/tests/tasks/lib/test_mlm_premasked.py
+++ b/tests/tasks/lib/test_mlm_premasked.py
@@ -1,12 +1,13 @@
 import transformers
 
 import jiant.shared.model_resolution as model_resolution
-import jiant.tasks as tasks
+
 from jiant.proj.main.modeling.primary import JiantTransformersModelFactory
+from jiant.tasks.retrieval import MLMPremaskedTask
 
 
 def test_tokenization_and_featurization():
-    task = tasks.MLMPremaskedTask(name="mlm_premasked", path_dict={})
+    task = MLMPremaskedTask(name="mlm_premasked", path_dict={})
     tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
     example = task.Example(guid=None, text="Hi, my name is Bob Roberts.", masked_spans=[[15, 18]],)
     tokenized_example = example.tokenize(tokenizer=tokenizer)

--- a/tests/tasks/lib/test_mlm_pretokenized.py
+++ b/tests/tasks/lib/test_mlm_pretokenized.py
@@ -1,14 +1,14 @@
 import transformers
 
 import jiant.shared.model_resolution as model_resolution
-import jiant.tasks as tasks
+from jiant.tasks.retrieval import MLMPretokenizedTask
 
 from jiant.shared.model_resolution import ModelArchitectures
 from jiant.proj.main.modeling.primary import JiantTransformersModelFactory
 
 
 def test_tokenization_and_featurization():
-    task = tasks.MLMPretokenizedTask(name="mlm_pretokenized", path_dict={})
+    task = MLMPretokenizedTask(name="mlm_pretokenized", path_dict={})
     tokenizer = transformers.RobertaTokenizer.from_pretrained("roberta-base")
     example = task.Example(
         guid=None,

--- a/tests/tasks/lib/test_mnli.py
+++ b/tests/tasks/lib/test_mnli.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 from jiant.shared import model_resolution
 from jiant.shared.model_resolution import ModelArchitectures
-from jiant.tasks import create_task_from_config_path
+from jiant.tasks.retrieval import create_task_from_config_path
 from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
 from jiant.proj.main.modeling.primary import JiantTransformersModelFactory
 

--- a/tests/tasks/lib/test_spr1.py
+++ b/tests/tasks/lib/test_spr1.py
@@ -6,7 +6,7 @@ import transformers
 from unittest.mock import Mock
 
 from jiant.shared import model_resolution
-from jiant.tasks import create_task_from_config_path
+from jiant.tasks.retrieval import create_task_from_config_path
 from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
 from jiant.proj.main.modeling.primary import JiantTransformersModelFactory
 

--- a/tests/tasks/lib/test_sst.py
+++ b/tests/tasks/lib/test_sst.py
@@ -3,7 +3,7 @@ from collections import Counter
 
 import numpy as np
 
-from jiant.tasks import create_task_from_config_path
+from jiant.tasks.retrieval import create_task_from_config_path
 from jiant.utils.testing.tokenizer import SimpleSpaceTokenizer
 
 

--- a/tests/utils/test_tokenization_normalization.py
+++ b/tests/utils/test_tokenization_normalization.py
@@ -3,7 +3,11 @@ import pytest
 import jiant.utils.tokenization_normalization as tn
 import jiant.utils.tokenization_utils as tu
 
-from transformers import BertTokenizer, XLMTokenizer, RobertaTokenizer, AlbertTokenizer
+from transformers import AlbertTokenizer
+from transformers import BertTokenizer
+from transformers import DebertaTokenizer
+from transformers import RobertaTokenizer
+from transformers import XLMTokenizer
 
 
 def test_process_wordpiece_token_sequence():


### PR DESCRIPTION
Importing `BatchMixin` in primary previously imported all tasks resulting in a circular import with `tokenization_normalization()`. This PR fixes the circular imports by removing `import *` in tasks `__init__.py`.