### PR TITLE
improve robustness of the simple runscript

### DIFF
--- a/jiant/proj/simple/runscript.py
+++ b/jiant/proj/simple/runscript.py
@@ -13,6 +13,7 @@ import jiant.shared.distributed as distributed
 import jiant.utils.zconf as zconf
 import jiant.utils.python.io as py_io
 from jiant.utils.python.logic import replace_none
+from jiant.utils.python.io import read_json
 
 
 @zconf.run_config
@@ -140,11 +141,16 @@ def run_simple(args: RunConfiguration, with_continue: bool = False):
         }
         for task_name in full_task_name_list:
             phases_to_do = []
+            config = None
             for phase, phase_task_list in phase_task_dict.items():
                 if task_name in phase_task_list and not os.path.exists(
                     os.path.join(args.exp_dir, "cache", hf_config.model_type, task_name, phase)
                 ):
-                    phases_to_do.append(phase)
+                    config = config or read_json(task_config_path_dict[task_name])
+                    if phase in config["paths"]:
+                        phases_to_do.append(phase)
+                    else:
+                        phase_task_list.remove(task_name)
             if not phases_to_do:
                 continue
             print(f"Tokenizing Task '{task_name}' for phases '{','.join(phases_to_do)}'")

--- a/jiant/proj/simple/runscript.py
+++ b/jiant/proj/simple/runscript.py
@@ -141,12 +141,11 @@ def run_simple(args: RunConfiguration, with_continue: bool = False):
         }
         for task_name in full_task_name_list:
             phases_to_do = []
-            config = None
             for phase, phase_task_list in phase_task_dict.items():
                 if task_name in phase_task_list and not os.path.exists(
                     os.path.join(args.exp_dir, "cache", hf_config.model_type, task_name, phase)
                 ):
-                    config = config or read_json(task_config_path_dict[task_name])
+                    config = read_json(task_config_path_dict[task_name])
                     if phase in config["paths"]:
                         phases_to_do.append(phase)
                     else:


### PR DESCRIPTION
Running the simple runscript with a task that does not have datasets for all the three phases (train/test/val) results in error. E.g., the following command:
```
python jiant/proj/simple/runscript.py run --run_name simple --exp_dir ${EXP_DIR}/ --data_dir ${EXP_DIR}/tasks --hf_pretrained_model_name_or_path roberta-base --tasks squad_v1 --train_batch_size 16 --num_train_epochs 3
```

results in the following error:
```
File "jiant/proj/simple/runscript.py", line 267, in <module>
    main()
  File "jiant/proj/simple/runscript.py", line 259, in main
    run_simple(args, with_continue=False)
  File "jiant/proj/simple/runscript.py", line 151, in run_simple
    tokenize_and_cache.main(
  File "jiant/proj/main/tokenize_and_cache.py", line 203, in main
    examples=task.get_test_examples(),
  File "jiant/tasks/lib/templates/squad_style/core.py", line 397, in get_test_examples
    return self.read_squad_examples(path=self.test_path, set_type=PHASE.TEST)
  File "jiant/tasks/core.py", line 150, in test_path
    return self.path_dict["test"]
KeyError: 'test'
```

This fix reads the config file of the given task and skips phases not specified in that config.

